### PR TITLE
NGI Pipeline server

### DIFF
--- a/ngi_pipeline/distributed/__init__.py
+++ b/ngi_pipeline/distributed/__init__.py
@@ -1,3 +1,0 @@
-""" Distributed module for NGI-pipeline
-"""
-

--- a/ngi_pipeline/log/loggers.py
+++ b/ngi_pipeline/log/loggers.py
@@ -57,18 +57,16 @@ def minimal_logger(namespace, config_file=None, to_file=True, debug=False):
     # File logger
     if to_file:
         cwd = os.path.dirname(os.path.realpath('.'))
-        if not config_file:
-            log.warn("No configuration file specified, logging in {}/ngi_pipeline.log".format(cwd))
-        else:
-            config = cl.load_config(config_file)
-            if not config.get('log_dir'):
-                log.warn("No logging path specified, logging in {}/ngi_pipeline.log".format(cwd))
+        log_path = os.path.join(cwd, 'ngi_pipeline.log')
+        if config_file or os.environ.get('NGI_CONFIG'):
+            if os.environ.get('NGI_CONFIG'):
+                config = cl.load_config(os.environ.get('NGI_CONFIG'))
             else:
-                log_path = os.path.join(config.get('log_dir'), 'ngi_pipeline.log')
-                log.info("Logging in file {}/ngi_pipeline.log".format(log_path))
-                fh = logging.FileHandler(log_path)
-                fh.setLevel(log_level)
-                fh.setFormatter(formatter)
-                log.addHandler(fh)
+                config = cl.load_config(config_file)
+            log_path = os.path.join(config.get('log_dir'), 'ngi_pipeline.log')
+        fh = logging.FileHandler(log_path)
+        fh.setLevel(log_level)
+        fh.setFormatter(formatter)
+        log.addHandler(fh)
 
     return log

--- a/ngi_pipeline/server/__init__.py
+++ b/ngi_pipeline/server/__init__.py
@@ -1,0 +1,2 @@
+"""Provide a web server allowing remote execution and status query.
+"""

--- a/ngi_pipeline/server/background.py
+++ b/ngi_pipeline/server/background.py
@@ -1,0 +1,132 @@
+"""Provide asynchronous background running of subprocesses.
+
+Modified from: https://github.com/vukasin/tornado-subprocess
+
+- Do not store all stdout/stderr, instead print out to avoid filling up buffer
+
+Copyright (c) 2012, Vukasin Toroman <vukasin@toroman.name>
+"""
+
+import subprocess
+import tornado.ioloop
+import time
+import fcntl
+import functools
+import os
+
+
+class GenericSubprocess (object):
+    def __init__ ( self, timeout=-1, **popen_args ):
+        self.args = dict()
+        self.args["stdout"] = subprocess.PIPE
+        self.args["stderr"] = subprocess.PIPE
+        self.args["close_fds"] = True
+        self.args.update(popen_args)
+        self.ioloop = None
+        self.expiration = None
+        self.pipe = None
+        self.timeout = timeout
+        self.streams = []
+        self.has_timed_out = False
+
+    def start(self):
+        """Spawn the task.
+
+        Throws RuntimeError if the task was already started."""
+        if not self.pipe is None:
+            raise RuntimeError("Cannot start task twice")
+
+        self.ioloop = tornado.ioloop.IOLoop.instance()
+        if self.timeout > 0:
+            self.expiration = self.ioloop.add_timeout( time.time() + self.timeout, self.on_timeout )
+        self.pipe = subprocess.Popen(**self.args)
+
+        self.streams = [ (self.pipe.stdout.fileno(), []),
+                         (self.pipe.stderr.fileno(), []) ]
+        for fd, d in self.streams:
+            flags = fcntl.fcntl(fd, fcntl.F_GETFL)| os.O_NDELAY
+            fcntl.fcntl( fd, fcntl.F_SETFL, flags)
+            self.ioloop.add_handler( fd,
+                                     self.stat,
+                                     self.ioloop.READ|self.ioloop.ERROR)
+
+    def on_timeout(self):
+        self.has_timed_out = True
+        self.cancel()
+
+    def cancel (self ) :
+        """Cancel task execution
+
+        Sends SIGKILL to the child process."""
+        try:
+            self.pipe.kill()
+        except:
+            pass
+
+    def stat( self, *args ):
+        '''Check process completion and consume pending I/O data'''
+        self.pipe.poll()
+        if not self.pipe.returncode is None:
+            '''cleanup handlers and timeouts'''
+            if not self.expiration is None:
+                self.ioloop.remove_timeout(self.expiration)
+            for fd, dest in  self.streams:
+                self.ioloop.remove_handler(fd)
+            '''schedulle callback (first try to read all pending data)'''
+            self.ioloop.add_callback(self.on_finish)
+        for fd, dest in  self.streams:
+            while True:
+                try:
+                    data = os.read(fd, 4096)
+                    if len(data) == 0:
+                        break
+                    print data.rstrip()
+                except:
+                    break
+    @property
+    def stdout(self):
+        return self.get_output(0)
+
+    @property
+    def stderr(self):
+        return self.get_output(1)
+
+    @property
+    def status(self):
+        return self.pipe.returncode
+
+    def get_output(self, index ):
+        return "".join(self.streams[index][1])
+
+    def on_finish(self):
+        raise NotImplemented()
+
+
+class Subprocess (GenericSubprocess):
+    """Create new instance
+
+    Arguments:
+        callback: method to be called after completion. This method should take 3 arguments: statuscode(int), stdout(str), stderr(str), has_timed_out(boolean)
+        timeout: wall time allocated for the process to complete. After this expires Task.cancel is called. A negative timeout value means no limit is set
+
+    The task is not started until start is called. The process will then be spawned using subprocess.Popen(**popen_args). The stdout and stderr are always set to subprocess.PIPE.
+    """
+
+    def __init__ ( self, callback, *args, **kwargs):
+        """Create new instance
+
+        Arguments:
+            callback: method to be called after completion. This method should take 3 arguments: statuscode(int), stdout(str), stderr(str), has_timed_out(boolean)
+            timeout: wall time allocated for the process to complete. After this expires Task.cancel is called. A negative timeout value means no limit is set
+
+        The task is not started until start is called. The process will then be spawned using subprocess.Popen(**popen_args). The stdout and stderr are always set to subprocess.PIPE.
+        """
+        self.callback = callback
+        self.done_callback = False
+        GenericSubprocess.__init__(self, *args, **kwargs)
+
+    def on_finish(self):
+        if not self.done_callback:
+            self.done_callback = True
+            '''prevent calling callback twice'''
+            self.ioloop.add_callback(functools.partial(self.callback, self.status, self.stdout, self.stderr, self.has_timed_out))

--- a/ngi_pipeline/server/handlers.py
+++ b/ngi_pipeline/server/handlers.py
@@ -1,0 +1,78 @@
+"""Provide ability to run bcbio-nextgen workflows.
+"""
+import collections
+import os
+import StringIO
+import sys
+import uuid
+
+import tornado.gen
+import tornado.web
+import yaml
+
+from ngi_pipeline.server import background
+
+
+def run_ngi_pipeline(args, callback=None):
+    run_id = str(uuid.uuid1())
+    def set_done(status, stdout, stderr, has_timed_out):
+        self.application.runmonitor.set_status(run_id, "finished" if status == 0 else "failed")
+    _run_local(args, set_done)
+    app.runmonitor.set_status(run_id, "running")
+    if callback:
+        callback(run_id)
+    else:
+        return run_id
+
+def _run_local(args, callback):
+    cmd = [os.path.join(os.path.dirname(sys.executable), "ngi_pipeline_start.py")] + args
+    p = background.Subprocess(callback, timeout=-1, args=[str(x) for x in cmd])
+    p.start()
+
+
+
+##################################
+#          Handlers              #
+##################################
+class FlowcellHandler(tornado.web.RequestHandler):
+    """ Handler to manage flowcell processing
+
+    GET /flowcell_analysis/(fc_dir)?restrict_to_projects=False&restrict_to_samples=False&restart_failed_jobs=False
+    """
+    @tornado.web.asynchronous
+    @tornado.gen.coroutine
+    def get(self, fc_dir):
+        args = ['process', 'flowcell', fc_dir, self.get_argument('restrict_to_projects', False),
+                self.get_argument('restrict_to_samples', False), self.get_argument('restart_failed_jobs', False)]
+        run_id = yield tornado.gen.Task(run_ngi_pipeline, args)
+        self.write(run_id)
+        self.finish()
+
+
+class TestHandler(tornado.web.RequestHandler):
+    """ Execute a 'sleep' command
+    """
+    @tornado.web.asynchronous
+    @tornado.gen.coroutine
+    def get(self, secs):
+        run_id = str(uuid.uuid1())
+        def set_done(status, stdout, stderr, has_timed_out):
+            self.application.runmonitor.set_status(run_id, "finished" if status == 0 else "failed")
+        cmd = ['sleep', secs]
+        p = background.Subprocess(set_done, timeout=-1, args=[str(x) for x in cmd])
+        p.start()
+        self.application.runmonitor.set_status(run_id, "running")
+
+        self.write(run_id)
+
+
+
+class StatusHandler(tornado.web.RequestHandler):
+    def get(self):
+        run_id = self.get_argument("run_id", None)
+        if run_id is None:
+            status = "server-up"
+        else:
+            status = self.application.runmonitor.get_status(run_id)
+        self.write(status)
+        self.finish()

--- a/ngi_pipeline/server/main.py
+++ b/ngi_pipeline/server/main.py
@@ -1,0 +1,28 @@
+"""Top level functionality for running a ngi_pipeline web server allowing remote jobs.
+"""
+import tornado.web
+import tornado.ioloop
+
+from ngi_pipeline.server import handlers
+
+def start(port):
+    """Run server with provided command line arguments.
+    """
+    application = tornado.web.Application([(r"/flowcell", handlers.FlowcellHandler),
+                                           (r"/status", handlers.StatusHandler),
+                                           (r"/test/([0-9]*)$", handlers.TestHandler)])
+    application.runmonitor = RunMonitor()
+    application.listen(port)
+    tornado.ioloop.IOLoop.instance().start()
+
+class RunMonitor:
+    """Track current runs and provide status.
+    """
+    def __init__(self):
+        self._running = {}
+
+    def set_status(self, run_id, status):
+        self._running[run_id] = status
+
+    def get_status(self, run_id):
+        return self._running.get(run_id, "not-running")

--- a/scripts/ngi_pipeline_start.py
+++ b/scripts/ngi_pipeline_start.py
@@ -9,7 +9,7 @@ import argparse
 
 from ngi_pipeline.conductor import flowcell
 from ngi_pipeline.log.loggers import minimal_logger
-#from ngi_pipeline.server import main as server_main
+from ngi_pipeline.server import main as server_main
 
 LOG = minimal_logger("ngi_pipeline_start")
 
@@ -20,7 +20,7 @@ if __name__ == "__main__":
 
     # Add subparser for the server
     parser_server = subparsers.add_parser('server', help="Start ngi_pipeline server")
-    parser_server.add_argument('-p', '--port', help="Port in where to run the application")
+    parser_server.add_argument('-p', '--port', type=int, help="Port in where to run the application")
 
 
     # Add subparser for the process
@@ -55,4 +55,5 @@ if __name__ == "__main__":
                                                 args.restrict_to_samples,
                                                 args.restart_failed_jobs)
     elif 'port' in args:
-        raise NotImplementedError('Sorry, the server stuff is not yet implemented...')
+        LOG.info('Starting ngi_pipeline server at port {}'.format(args.port))
+        server_main.start(args.port)


### PR DESCRIPTION
This code implements the tornado server to run tasks on the background. I've defined a /test/_seconds_ call that will spawn a task that will "sleep" for n seconds so you can try this locally.
#### How-To

Start the server:

```
python ngi_pipeline_start.py server --port 8080
```

Call the test task with a determined number of seconds. This will return a task id that you can use to check the status of the task:

```
id=`curl -X GET http://localhost:8080/test/100`
```

Use the returned id to check the status of the task:

```
curl -X GET http://localhost:8080/status?run_id=$id
running
```

After 100 seconds...

```
curl -X GET http://localhost:8080/status?run_id=$id
finished
```

**STILL** needs to be tested in UPPMAX with real data, but you can check the codebase on the meantime. 
