### PR TITLE
fixed the logging

### DIFF
--- a/ngi_pipeline/log/loggers.py
+++ b/ngi_pipeline/log/loggers.py
@@ -4,6 +4,7 @@ log module
 import logging
 import os
 import sys
+import yaml
 
 #from ngi_pipeline.utils.config import load_yaml_config
 from Queue import Queue
@@ -60,10 +61,12 @@ def minimal_logger(namespace, config_file=None, to_file=True, debug=False):
         log_path = os.path.join(cwd, 'ngi_pipeline.log')
         if config_file or os.environ.get('NGI_CONFIG'):
             if os.environ.get('NGI_CONFIG'):
-                config = cl.load_config(os.environ.get('NGI_CONFIG'))
+                with open(os.environ.get('NGI_CONFIG'), "r") as conf_file:
+                    config=yaml.load(conf_file)
             else:
-                config = cl.load_config(config_file)
-            log_path = os.path.join(config.get('log_dir'), 'ngi_pipeline.log')
+                with open(config_file, "r") as conf_file:
+                    config=yaml.load(conf_file)
+            log_path = os.path.join(config.get('log_dir', ''), 'ngi_pipeline.log')
         fh = logging.FileHandler(log_path)
         fh.setLevel(log_level)
         fh.setFormatter(formatter)


### PR DESCRIPTION
cl.load uses the bcbio method to read yaml configuration files. The code originates in scilifelab logger.
There's no point in using bcbio to read yaml files. 
context managers are for @mariogiov 
the empty string second argument is there because if the config file does not have the required key, config.get() returns None (default behavior) and os.path.join breaks on trying to join None objects.
The problematic code is located here : lib/python2.7/posixpath.py, line 77.
There is no testing for None, but there is one for ''. 
