### PR TITLE
can't display a value we failed to get

### DIFF
--- a/ngi_pipeline/engines/piper_ngi/__init__.py
+++ b/ngi_pipeline/engines/piper_ngi/__init__.py
@@ -269,7 +269,7 @@ def sbatch_piper_job(command_line, workflow_name, project, sample, libprep=None,
                 required_total_autosomal_coverage = int(config.get("piper", {}).get("sample", {}).get("required_autosomal_coverage"))
             except (TypeError, ValueError) as e:
                 LOG.error('Unable to parse required total autosomal coverage value from '
-                          'config file (value was "{}"); using 30 instead.'.format(required_total_autosomal_coverage))
+                          'config file, using 30 instead.'
             required_total_autosomal_coverage = 30
             bash_conditional = \
             ('source activate {conda_environment}\n'


### PR DESCRIPTION
required_total_autosomal_coverage is not defined because we raised an exception, so we can't display it in the log. 
