### PR TITLE
Don't copy symlinks as symlinks

### DIFF
--- a/ngi_pipeline/engines/piper_ngi/__init__.py
+++ b/ngi_pipeline/engines/piper_ngi/__init__.py
@@ -192,7 +192,7 @@ def sbatch_piper_sample(command_line_list, workflow_name, project, sample, libpr
                       "Copying any pre-existing alignment qc files"]
     for echo_text, input_files, output_dir in zip(echo_text_list, input_files_list, output_dirs_list):
         if input_files:
-            sbatch_text_list.append("\necho -e '\n\n{}'".format(echo_text))
+            sbatch_text_list.append("\necho -e '\\n\\n{}'".format(echo_text))
             sbatch_text_list.append("mkdir -p {}".format(output_dir))
             sbatch_text_list.append(("rsync -rptoDv {input_files} "
                                      "{output_directory}/").format(input_files=" ".join(input_files),
@@ -200,7 +200,7 @@ def sbatch_piper_sample(command_line_list, workflow_name, project, sample, libpr
     sbatch_text_list.append("\n# Run the actual commands")
     for command_line in command_line_list:
         sbatch_text_list.append(command_line)
-    sbatch_text_list.append("\necho -e '\n\nCopying back the resulting analysis files'")
+    sbatch_text_list.append("\necho -e '\\n\\nCopying back the resulting analysis files'")
     sbatch_text_list.append("mkdir -p {}".format(perm_analysis_dir))
     sbatch_text_list.append("rsync -rptoDv {}/ {}/\n".format(scratch_analysis_dir, perm_analysis_dir))
 


### PR DESCRIPTION
Okay so after all my snarky RTFM talk, I was doing the rsync wrong and copying symlinks to the node as symlinks, which means that the files on scratch in the node were in this case symlinks back to the original files in permanent storage. Ha-ha. Nice work Mario.
