### PR TITLE
Don't rerun QC analyses (FastQC, fastq_screen) if not needed

### DIFF
--- a/ngi_pipeline/engines/qc_ngi/launchers.py
+++ b/ngi_pipeline/engines/qc_ngi/launchers.py
@@ -19,41 +19,27 @@ def analyze(project, sample, config=None, config_file_path=None):
     """The main entry point for the qc pipeline."""
     LOG.info("Processing project/sample {}/{}".format(project, sample))
 
-    # Two paths diverged in a yellow wood
     project_analysis_path = os.path.join(project.base_path,
                                          "ANALYSIS",
                                          project.project_id,
                                          "qc_ngi")
-    # and sorry I could not travel both
     sample_analysis_path = os.path.join(project_analysis_path, sample.name)
-    # and be one traveler, long I stood
     log_dir_path = os.path.join(project_analysis_path, "logs")
-    # and looked down one as far as I could
     safe_makedir(sample_analysis_path)
-    # To where it bent in the undergrowth
     safe_makedir(log_dir_path)
-    # I need to go to sleep
 
     fastq_files_to_process = []
-    # I suppose I -should- have quoted the other one
     src_fastq_base = os.path.join(project.base_path, "DATA",
                                   project.project_id, sample.name)
-    # Whose woods these are I think I know
     for libprep in sample:
-        # His house is in the village though
         for seqrun in libprep:
-            # He will not see mt stopping here
             for fastq_file in seqrun:
-                # To watch
                 path_to_src_fastq = os.path.join(src_fastq_base,
                                                  libprep.name,
                                                  seqrun.name,
                                                  fastq_file)
-                # his woods
                 fastq_files_to_process.append(path_to_src_fastq)
-    # fill up
     paired_fastq_files = find_fastq_read_pairs(fastq_files_to_process).values()
-    # with snow
     qc_cl_list = return_cls_for_workflow("qc", paired_fastq_files, sample_analysis_path)
 
     sbatch_file_path = create_sbatch_file(qc_cl_list, project, sample, config)

--- a/ngi_pipeline/engines/qc_ngi/launchers.py
+++ b/ngi_pipeline/engines/qc_ngi/launchers.py
@@ -31,14 +31,14 @@ def analyze(project, sample, config=None, config_file_path=None):
     fastq_files_to_process = []
     src_fastq_base = os.path.join(project.base_path, "DATA",
                                   project.project_id, sample.name)
-    for libprep in sample:
-        for seqrun in libprep:
-            for fastq_file in seqrun:
-                path_to_src_fastq = os.path.join(src_fastq_base,
-                                                 libprep.name,
-                                                 seqrun.name,
-                                                 fastq_file)
-                fastq_files_to_process.append(path_to_src_fastq)
+    #for libprep in sample:
+    #    for seqrun in libprep:
+    #        for fastq_file in seqrun:
+    #            path_to_src_fastq = os.path.join(src_fastq_base,
+    #                                             libprep.name,
+    #                                             seqrun.name,
+    #                                             fastq_file)
+    #            fastq_files_to_process.append(path_to_src_fastq)
     paired_fastq_files = find_fastq_read_pairs(fastq_files_to_process).values()
     qc_cl_list = return_cls_for_workflow("qc", paired_fastq_files, sample_analysis_path)
 
@@ -51,6 +51,35 @@ def analyze(project, sample, config=None, config_file_path=None):
     else:
         LOG.info('Queued qc sbatch file for project/sample '
                  '"{}"/"{}": slurm job id {}'.format(project, sample, slurm_job_id))
+
+
+def files_need_analysis(project, sample):
+    """Given an NGIProject and NGISample object, determine if the qc files
+    need to be generated: check if the modification time of the input files
+    is newer than that of the qc files to be generated (if they exist).
+
+    :param NGIProject project: The project in question
+    :param NGISample sample: The sample " "
+    """
+
+    project_analysis_path = os.path.join(project.base_path,
+                                         "ANALYSIS",
+                                         project.project_id,
+                                         "qc_ngi")
+
+    fastq_files_to_process = []
+    src_fastq_base = os.path.join(project.base_path, "DATA",
+                                  project.project_id, sample.name)
+    for libprep in sample:
+        for seqrun in libprep:
+            for fastq_file in seqrun:
+                path_to_src_fastq = os.path.join(src_fastq_base,
+                                                 libprep.name,
+                                                 seqrun.name,
+                                                 fastq_file)
+                fastq_files_to_process.append(path_to_src_fastq)
+    for fastq_file in fastq_files_to_process:
+        
 
 
 

--- a/ngi_pipeline/engines/qc_ngi/launchers.py
+++ b/ngi_pipeline/engines/qc_ngi/launchers.py
@@ -31,45 +31,6 @@ def analyze(project, sample, config=None, config_file_path=None):
     fastq_files_to_process = []
     src_fastq_base = os.path.join(project.base_path, "DATA",
                                   project.project_id, sample.name)
-    #for libprep in sample:
-    #    for seqrun in libprep:
-    #        for fastq_file in seqrun:
-    #            path_to_src_fastq = os.path.join(src_fastq_base,
-    #                                             libprep.name,
-    #                                             seqrun.name,
-    #                                             fastq_file)
-    #            fastq_files_to_process.append(path_to_src_fastq)
-    paired_fastq_files = find_fastq_read_pairs(fastq_files_to_process).values()
-    qc_cl_list = return_cls_for_workflow("qc", paired_fastq_files, sample_analysis_path)
-
-    sbatch_file_path = create_sbatch_file(qc_cl_list, project, sample, config)
-    try:
-        slurm_job_id = queue_sbatch_file(sbatch_file_path) 
-    except RuntimeError as e:
-        LOG.error('Failed to queue qc sbatch file for project/sample '
-                  '"{}"/"{}"!'.format(project, sample))
-    else:
-        LOG.info('Queued qc sbatch file for project/sample '
-                 '"{}"/"{}": slurm job id {}'.format(project, sample, slurm_job_id))
-
-
-def files_need_analysis(project, sample):
-    """Given an NGIProject and NGISample object, determine if the qc files
-    need to be generated: check if the modification time of the input files
-    is newer than that of the qc files to be generated (if they exist).
-
-    :param NGIProject project: The project in question
-    :param NGISample sample: The sample " "
-    """
-
-    project_analysis_path = os.path.join(project.base_path,
-                                         "ANALYSIS",
-                                         project.project_id,
-                                         "qc_ngi")
-
-    fastq_files_to_process = []
-    src_fastq_base = os.path.join(project.base_path, "DATA",
-                                  project.project_id, sample.name)
     for libprep in sample:
         for seqrun in libprep:
             for fastq_file in seqrun:
@@ -78,9 +39,18 @@ def files_need_analysis(project, sample):
                                                  seqrun.name,
                                                  fastq_file)
                 fastq_files_to_process.append(path_to_src_fastq)
-    for fastq_file in fastq_files_to_process:
-        
+    paired_fastq_files = find_fastq_read_pairs(fastq_files_to_process).values()
+    qc_cl_list = return_cls_for_workflow("qc", paired_fastq_files, sample_analysis_path)
 
+    sbatch_file_path = create_sbatch_file(qc_cl_list, project, sample, config)
+    try:
+        slurm_job_id = queue_sbatch_file(sbatch_file_path)
+    except RuntimeError as e:
+        LOG.error('Failed to queue qc sbatch file for project/sample '
+                  '"{}"/"{}"!'.format(project, sample))
+    else:
+        LOG.info('Queued qc sbatch file for project/sample '
+                 '"{}"/"{}": slurm job id {}'.format(project, sample, slurm_job_id))
 
 
 def queue_sbatch_file(sbatch_file_path):

--- a/ngi_pipeline/engines/qc_ngi/workflows.py
+++ b/ngi_pipeline/engines/qc_ngi/workflows.py
@@ -159,8 +159,9 @@ def workflow_fastq_screen(input_files, output_dir, config):
     for elt in input_files:
         # This may be a read pair
         if type(elt) is list:
-            # fastq_screen uses the name of the first read of the pair for output files
+            # Changing list to tuple so we can use it in the set() (lists aren't hashable)
             elt = tuple(elt)
+            # fastq_screen uses the name of the first read of the pair for output files
             fastq_file = elt[0]
         else:
             fastq_file = elt

--- a/ngi_pipeline/engines/qc_ngi/workflows.py
+++ b/ngi_pipeline/engines/qc_ngi/workflows.py
@@ -119,6 +119,8 @@ def workflow_fastqc(input_files, output_dir, config):
                                               fastqc_path=fastqc_path,
                                               num_threads=num_threads,
                                               fastq_files=" ".join(fastq_to_analyze)))
+    if not cl_list:
+        LOG.info("FastQC analysis not needed or input files were invalid.")
     return cl_list
 
 

--- a/ngi_pipeline/engines/qc_ngi/workflows.py
+++ b/ngi_pipeline/engines/qc_ngi/workflows.py
@@ -68,6 +68,12 @@ def workflow_fastqc(input_files, output_dir, config):
     :rtype: list
     :raises ValueError: If the FastQC path is not given or is not on PATH
     """
+    fastq_files = flatten(input_files) # FastQC cares not for your "read pairs"
+    # Verify that we in fact need to run this on these files
+    fastqc_output_template = "{}.somethingorother"
+    for fastq_file in fastq_files:
+
+
     # Get the path to the fastqc command
     fastqc_path = config.get("paths", {}).get("fastqc")
     if not fastqc_path:
@@ -79,7 +85,6 @@ def workflow_fastqc(input_files, output_dir, config):
                              'available on PATH; cannot proceed with FastQC '
                              'workflow.')
     num_threads = config.get("qc", {}).get("fastqc", {}).get("threads") or 1
-    fastq_files = flatten(input_files) # FastQC cares not for your "read pairs"
     # Construct the command lines
     cl_list = []
     # Module loading


### PR DESCRIPTION
Checks for the existence of the output files and that they are newer (more recently modified) than the input fastq files