### PR TITLE
Genotype jobs rerun without forcing

### DIFF
--- a/ngi_pipeline/engines/piper_ngi/launchers.py
+++ b/ngi_pipeline/engines/piper_ngi/launchers.py
@@ -44,7 +44,7 @@ from ngi_pipeline.utils.slurm import get_slurm_job_status
 LOG = minimal_logger(__name__)
 
 @with_ngi_config
-def analyze(project, sample, exec_mode="sbatch", restart_finished_jobs=False, 
+def analyze(project, sample, exec_mode="sbatch", restart_finished_jobs=False,
             restart_running_jobs=False, level="sample", genotype_file=None,
             config=None, config_file_path=None):
     """Analyze data at the sample level.
@@ -152,7 +152,7 @@ def analyze(project, sample, exec_mode="sbatch", restart_finished_jobs=False,
 @with_ngi_config
 def genotype(project, sample, exec_mode="sbatch",
              genotype_file=None,
-             restart_finished_jobs=False,
+             restart_finished_jobs=True,
              restart_running_jobs=False,
              level="genotype",
              config=None, config_file_path=None):

--- a/ngi_pipeline/engines/piper_ngi/launchers.py
+++ b/ngi_pipeline/engines/piper_ngi/launchers.py
@@ -213,10 +213,12 @@ def genotype(project, sample, exec_mode="sbatch",
                 remove_previous_genotype_analyses(project)
                 if exec_mode == "sbatch":
                     process_id = None
+                    # "restart_finished_jobs" in this case checks against Charon,
+                    # and that value refers to normal analysis, not genotyping
                     slurm_job_id = sbatch_piper_sample([setup_xml_cl, piper_cl],
                                                        workflow_subtask,
                                                        project, sample,
-                                                       restart_finished_jobs=restart_finished_jobs)
+                                                       restart_finished_jobs=True)
                     for x in xrange(10): # Time delay to let sbatch get its act together (takes a few seconds to be visible with sacct)
                         try:
                             get_slurm_job_status(slurm_job_id)
@@ -366,8 +368,7 @@ def sbatch_piper_sample(command_line_list, workflow_name, project, sample,
             sbatch_text_list.append("module load {}".format(module_name))
 
     project, src_aln_files, src_alnqc_files = \
-            collect_files_for_sample_analysis(project, sample, 
-                                                restart_finished_jobs)
+            collect_files_for_sample_analysis(project, sample, restart_finished_jobs)
 
     # Fastq files to copy
     fastq_src_dst_list = []


### PR DESCRIPTION
I'll add some file-checking to this but for now it's up to the user if they want to rerun analyses