### PR TITLE
Bugfix: missing space in rsync command

### DIFF
--- a/ngi_pipeline/engines/piper_ngi/launchers.py
+++ b/ngi_pipeline/engines/piper_ngi/launchers.py
@@ -361,7 +361,7 @@ def sbatch_piper_sample(command_line_list, workflow_name, project, sample,
     if files_to_copy:
         sbatch_text_list.append("echo -ne '\\n\\nCopying pre-existing analysis files at '")
         sbatch_text_list.append("date")
-        sbatch_text_list.append(("rsync -rptoDLv {input_files}"
+        sbatch_text_list.append(("rsync -rptoDLv {input_files} "
                                  "{output_directory}/").format(input_files=" ".join(files_to_copy),
                                                                output_directory=scratch_analysis_dir))
         # Delete pre-existing analysis files after copy


### PR DESCRIPTION
Dumb. Now the `--keep-existing-files` flag will work.