### PR TITLE
loosen up requirements for nose and python-dateutil

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,10 +10,10 @@ importlib==1.0.3
 inflect==0.2.5
 ipdb==0.8
 ipython==2.1.0
-nose==1.3.3
+nose>=1.3.3
 nose-exclude==0.2.0
 psutil==2.1.1
-python-dateutil==1.5
+python-dateutil>=1.5
 requests
 tornado
 wsgiref==0.1.2


### PR DESCRIPTION
- these requirements were in conflict with `ngi_reports`