### PR TITLE
Added a test end-point to the ngi_pipline server

### DIFF
--- a/ngi_pipeline/server/handlers.py
+++ b/ngi_pipeline/server/handlers.py
@@ -72,6 +72,14 @@ class TestHandler(tornado.web.RequestHandler):
         self.write(run_id)
 
 
+class TestFlowcellHandler(tornado.web.RequestHandler):
+
+    def get(self, runfolder_name):
+        if not runfolder_name:
+            raise AttributeError("Need to provide a runfolder name")
+        self.write("Test started: {}".format(runfolder_name))
+        self.finish()
+
 
 class StatusHandler(tornado.web.RequestHandler):
     def get(self):

--- a/ngi_pipeline/server/main.py
+++ b/ngi_pipeline/server/main.py
@@ -10,7 +10,9 @@ def start(port):
     """
     application = tornado.web.Application([(r"/flowcell_analysis/([^/]*)$", handlers.FlowcellHandler),
                                            (r"/status", handlers.StatusHandler),
-                                           (r"/test/([0-9]*)$", handlers.TestHandler)])
+                                           (r"/test/([0-9]*)$", handlers.TestHandler),
+                                           (r"/test_flowcell_analysis/([^/]*)$", handlers.TestFlowcellHandler)
+                                           ])
     application.runmonitor = RunMonitor()
     application.listen(port)
     tornado.ioloop.IOLoop.instance().start()


### PR DESCRIPTION
For integration tests it would be great to have a end-point which one can issue requests to in the same way that one can issue requests to the real flowcell analysis end-point, but without actually starting anything.