### PR TITLE
fixed search for uppsala projects in locate_projects

### DIFF
--- a/ngi_pipeline/conductor/flowcell.py
+++ b/ngi_pipeline/conductor/flowcell.py
@@ -197,7 +197,9 @@ def setup_analysis_directory_structure(fc_dir, projects_to_analyze,
     if not restrict_to_projects: restrict_to_projects = []
     if not restrict_to_samples: restrict_to_samples = []
     config["quiet"] = quiet # Hack because I enter here from a script sometimes
-    pattern="(.+(?:{}|{}))\/.+".format(config["analysis"]["sthlm_root"], config["analysis"]["upps_root"])
+    pattern = "(.+(?:{}|{}))\/.+".format(
+        config["analysis"].get("sthlm_root", "this_is_not_a_valid_path"),
+        config["analysis"].get("upps_root", "this_is_not_a_valid_path"))
     matches=re.match(pattern, fc_dir)
     if matches:
         flowcell_root=matches.group(1)

--- a/ngi_pipeline/tests/utils/test_filesystem.py
+++ b/ngi_pipeline/tests/utils/test_filesystem.py
@@ -19,7 +19,7 @@ class TestFilesystemUtils(unittest.TestCase):
     def test_locate_flowcell(self):
         flowcell_name = "temp_flowcell"
         tmp_dir = tempfile.mkdtemp()
-        config = {'environment': {'flowcell_inbox': tmp_dir}}
+        config = {'environment': {'flowcell_inbox': [tmp_dir]}}
         with self.assertRaises(ValueError):
             # Should raise ValueError if flowcell can't be found
             locate_flowcell(flowcell=flowcell_name, config=config)

--- a/ngi_pipeline/utils/filesystem.py
+++ b/ngi_pipeline/utils/filesystem.py
@@ -105,8 +105,8 @@ def locate_project(project, subdir="DATA", resolve_symlinks=True,
     else:
         try:
             base_root = config["analysis"]["base_root"]
-            node_roots = [config["analysis"]["sthlm_root"],
-                         config["analysis"].get("upps_root")]
+            node_roots = [config["analysis"].get("sthlm_root"),
+                          config["analysis"].get("upps_root")]
             top_dir = config["analysis"]["top_dir"]
         except (KeyError, TypeError) as e:
             raise ValueError('Path to project data directory not available in '
@@ -121,8 +121,7 @@ def locate_project(project, subdir="DATA", resolve_symlinks=True,
                     try:
                         return os.path.realpath(project_dir)
                     except OSError as e:
-                        # should this be thrown?
-                        pass
+                        raise
                 return project_dir
         raise ValueError('project directory passed as project name (not '
                          'full path) and does not exist under project '


### PR DESCRIPTION
- Uppsala projects would not be found as long as the Sthlm project_data_dir was a valid path. Changed so that all alternative locations are searched.