### PR TITLE
moving lmod to the configuration file

### DIFF
--- a/nestor_ngi_config.yaml
+++ b/nestor_ngi_config.yaml
@@ -35,6 +35,7 @@ logging:
 
 
 paths: # Hard code paths here if you are that kind of a person
+    lmod_path: "/usr/lib/lmod/lmod/libexec/lmod"
     binaries:
         #bowtie2:
         #fastqc:

--- a/nestor_ngi_config.yaml
+++ b/nestor_ngi_config.yaml
@@ -35,7 +35,6 @@ logging:
 
 
 paths: # Hard code paths here if you are that kind of a person
-    lmod_path: "/usr/lib/lmod/lmod/libexec/lmod"
     binaries:
         #bowtie2:
         #fastqc:

--- a/ngi_pipeline/utils/filesystem.py
+++ b/ngi_pipeline/utils/filesystem.py
@@ -40,7 +40,7 @@ def load_modules(modules_list, config=None, config_file_path=None):
     error_msgs = []
     for module in modules_list:
         # Yuck
-        lmod_location=config['paths'].get('lmod_path', "/usr/lib/lmod/lmod/libexec/lmod")
+        lmod_location=os.environ.get('LMOD_CMD', "/usr/lib/lmod/lmod/libexec/lmod")
         cl = "{lmod} python load {module}".format(lmod=lmod_location,
                                                   module=module)
         p = subprocess.Popen(shlex.split(cl), stdout=subprocess.PIPE,

--- a/ngi_pipeline/utils/filesystem.py
+++ b/ngi_pipeline/utils/filesystem.py
@@ -23,7 +23,8 @@ from requests.exceptions import Timeout
 
 LOG = minimal_logger(__name__)
 
-def load_modules(modules_list):
+@with_ngi_config
+def load_modules(modules_list, config=None, config_file_path=None):
     """
     Takes a list of environment modules to load (in order) and
     loads them using modulecmd python load
@@ -39,7 +40,7 @@ def load_modules(modules_list):
     error_msgs = []
     for module in modules_list:
         # Yuck
-        lmod_location = "/usr/lib/lmod/lmod/libexec/lmod"
+        lmod_location=config['paths'].get('lmod_path', "/usr/lib/lmod/lmod/libexec/lmod")
         cl = "{lmod} python load {module}".format(lmod=lmod_location,
                                                   module=module)
         p = subprocess.Popen(shlex.split(cl), stdout=subprocess.PIPE,


### PR DESCRIPTION
Apparently, you can't use lmod like this on Irma. Therefore, moving the path to the configuration file allows any lmod to be used. 