### PR TITLE
Updated origin & let db create folders

### DIFF
--- a/ngi_pipeline/engines/piper_ngi/database.py
+++ b/ngi_pipeline/engines/piper_ngi/database.py
@@ -59,7 +59,11 @@ def _init_engine(database_path):
 def create_database_populate_schema(location):
     """Create the database and populate it with the schema."""
     engine = _init_engine(location)
-    # Create the tables
+    # Create the folder if necessary
+    if not os.path.exists( os.path.dirname(location) ):
+        try:
+            os.makedirs( os.path.dirname(location)) 
+    # Create the tables & sqlite file
     Base.metadata.create_all(engine)
     return engine
 

--- a/ngi_pipeline/utils/communication.py
+++ b/ngi_pipeline/utils/communication.py
@@ -8,7 +8,7 @@ from ngi_pipeline.log.loggers import minimal_logger
 
 LOG = minimal_logger(__name__)
 
-def mail(recipient, subject, text, origin="ngi_pipeline"):
+def mail(recipient, subject, text, origin="ngi_pipeline@scilifelab.se"):
     msg = MIMEText(text)
     msg['Subject'] = '[NGI_pipeline] {}'.format(subject)
     msg['From'] = origin
@@ -21,7 +21,7 @@ def mail(recipient, subject, text, origin="ngi_pipeline"):
 def mail_analysis(project_name, sample_name=None, engine_name=None,
                   level="ERROR", info_text=None, workflow=None,
                   recipient="ngi_pipeline_operators@scilifelab.se",
-                  subject=None, origin="ngi_pipeline",
+                  subject=None, origin="ngi_pipeline@scilifelab.se",
                   config=None, config_file_path=None ):
 
     # check for mail recipient among the config values


### PR DESCRIPTION
Fixes for two small problems:
Uppmax was having some problems with invalid sender.
If the config pointed the database to a folder that didn't exist, ngi_pipeline refused to create the db. It would however create the db if the folder existed.

Changes or downright refusal is ok. Just play nice.