### PR TITLE
adding multiqc as a post_process step

### DIFF
--- a/ngi_pipeline/utils/post_analysis.py
+++ b/ngi_pipeline/utils/post_analysis.py
@@ -10,7 +10,7 @@ def run_multiqc(base_path, project_id, project_name):
     project_path=os.path.join(base_path, 'ANALYSIS', project_id)
     result_path=os.path.join(base_path, 'ANALYSIS', project_id, 'multiqc')
     safe_makedir(result_path)
-    command=['multiqc', project_path, '-o', result_path, '-i', project_name, '-n', project_name, '-q']
+    command=['multiqc', project_path, '-o', result_path, '-i', project_name, '-n', project_name, '-q', '-f']
     multiqc_stdout=''
     multiqc_stderr=''
     try:

--- a/ngi_pipeline/utils/post_analysis.py
+++ b/ngi_pipeline/utils/post_analysis.py
@@ -1,0 +1,26 @@
+
+from ngi_pipeline.log.loggers import minimal_logger
+from ngi_pipeline.utils.classes import with_ngi_config
+from ngi_pipeline.utils.filesystem import execute_command_line, safe_makedir
+
+import os
+
+def run_multiqc(base_path, project_id, project_name):
+
+    project_path=os.path.join(base_path, 'ANALYSIS', project_id)
+    result_path=os.path.join(base_path, 'ANALYSIS', project_id, 'multiqc')
+    safe_makedir(result_path)
+    command=['multiqc', project_path, '-o', result_path, '-i', project_name, '-n', project_name, '-q']
+    multiqc_stdout=''
+    multiqc_stderr=''
+    try:
+        handle=execute_command_line(command)
+        (multiqc_stdout, multiqc_stderr)=handle.communicate()
+        if multiqc_stdout or multiqc_stderr:
+            combined_output="{}\n{}".format(multiqc_stdout, multiqc_stderr)
+            raise Exception(combined_output)
+
+    except:
+        raise
+
+


### PR DESCRIPTION
This adds a multiqc run at the end of any sample analysis. This assumes that "multiqc" can be called from within the environment used by the ngi_pipeline. 
If it fails, you'll get a log message, and that's about it. 

The analysis will be stored in a folder named "multiqc" alongside "piper_ngi" and "qc_ngi".