### PR TITLE
Changed origin in emails to valid sender

### DIFF
--- a/ngi_pipeline/__init__.py
+++ b/ngi_pipeline/__init__.py
@@ -1,4 +1,4 @@
 """ Main ngi_pipeline module
 """
 __import__('pkg_resources').declare_namespace(__name__)
-__version__="0.1.1"
+__version__="0.1.2"

--- a/ngi_pipeline/utils/communication.py
+++ b/ngi_pipeline/utils/communication.py
@@ -8,7 +8,7 @@ from ngi_pipeline.log.loggers import minimal_logger
 
 LOG = minimal_logger(__name__)
 
-def mail(recipient, subject, text, origin="ngi_pipeline@scilifelab.se"):
+def mail(recipient, subject, text, origin="seqmaster@scilifelab.se"):
     msg = MIMEText(text)
     msg['Subject'] = '[NGI_pipeline] {}'.format(subject)
     msg['From'] = origin
@@ -21,7 +21,7 @@ def mail(recipient, subject, text, origin="ngi_pipeline@scilifelab.se"):
 def mail_analysis(project_name, sample_name=None, engine_name=None,
                   level="ERROR", info_text=None, workflow=None,
                   recipient="ngi_pipeline_operators@scilifelab.se",
-                  subject=None, origin="ngi_pipeline@scilifelab.se",
+                  subject=None, origin="seqmaster@scilifelab.se",
                   config=None, config_file_path=None ):
 
     # check for mail recipient among the config values


### PR DESCRIPTION
There was some talk a while back that Irma's configuration combined with automated e-mailing caused some issues. Namely if the origin wasn't considered valid then the mail would just bounce around and wreck all sorts of havoc. 

Afaik ngi_pipeline@scilifelab.se isn't an actual e-mail address but just a cute way for it to look like one, so this fix changes it to seqmaster@scilifelab.se instead.

Opinions are appreciated.