### PR TITLE
Updates to sort out irma compatibility

### DIFF
--- a/ngi_pipeline/__init__.py
+++ b/ngi_pipeline/__init__.py
@@ -1,4 +1,4 @@
 """ Main ngi_pipeline module
 """
 __import__('pkg_resources').declare_namespace(__name__)
-__version__="0.1.1"
+__version__="0.1.2"

--- a/ngi_pipeline/conductor/flowcell.py
+++ b/ngi_pipeline/conductor/flowcell.py
@@ -197,15 +197,16 @@ def setup_analysis_directory_structure(fc_dir, projects_to_analyze,
     if not restrict_to_projects: restrict_to_projects = []
     if not restrict_to_samples: restrict_to_samples = []
     config["quiet"] = quiet # Hack because I enter here from a script sometimes
-    pattern="(.+(?:{}|{}))\/.+".format(config["analysis"]["sthlm_root"], config["analysis"]["upps_root"])
+    #Checks flowcell path to establish which group owns it
+    pattern=".+({}|{})\/.+".format(config["analysis"]["sthlm_root"], config["analysis"]["upps_root"])
     matches=re.match(pattern, fc_dir)
     if matches:
-        flowcell_root=matches.group(1)
+        flowcell_uppnexid=matches.group(1)
     else:
         LOG.error("cannot guess which project the flowcell {} belongs to".format(fc_dir))
         raise RuntimeError
 
-    analysis_top_dir = os.path.abspath(os.path.join(flowcell_root,config["analysis"]["top_dir"]))
+    analysis_top_dir = os.path.abspath(os.path.join(config["analysis"]["base_root"],flowcell_uppnexid,config["analysis"]["top_dir"]))
     try:
         safe_makedir(analysis_top_dir)
     except OSError as e:

--- a/ngi_pipeline/engines/piper_ngi/command_creation_config.py
+++ b/ngi_pipeline/engines/piper_ngi/command_creation_config.py
@@ -38,6 +38,7 @@ def build_piper_cl(project, workflow_name, setup_xml_path, exit_code_path,
     piper_rootdir = config.get("piper", {}).get("path_to_piper_rootdir")
     piper_global_config_path = \
                     (os.environ.get("PIPER_GLOB_CONF_XML") or
+                     os.environ.get("PIPER_CONF") or
                      config.get("piper", {}).get("path_to_piper_globalconfig") or
                      (os.path.join(piper_rootdir, "globalConfig.xml") if
                      piper_rootdir else None))
@@ -49,6 +50,7 @@ def build_piper_cl(project, workflow_name, setup_xml_path, exit_code_path,
     # QScripts directory
     try:
         piper_qscripts_dir = (os.environ.get("PIPER_QSCRIPTS_DIR") or
+                              os.environ.get("PIPER_QSCRIPTS") or
                               config['piper']['path_to_piper_qscripts'])
     except KeyError:
         raise ValueError('Could not find Piper QScripts directory in config file or '

--- a/ngi_pipeline/utils/communication.py
+++ b/ngi_pipeline/utils/communication.py
@@ -21,7 +21,7 @@ def mail(recipient, subject, text, origin="ngi_pipeline@scilifelab.se"):
 def mail_analysis(project_name, sample_name=None, engine_name=None,
                   level="ERROR", info_text=None, workflow=None,
                   recipient="ngi_pipeline_operators@scilifelab.se",
-                  subject=None, origin="ngi_pipeline@scilifelab.se",
+                  subject=None, origin="seqmaster@scilifelab.se",
                   config=None, config_file_path=None ):
 
     # check for mail recipient among the config values

--- a/ngi_pipeline/utils/communication.py
+++ b/ngi_pipeline/utils/communication.py
@@ -21,7 +21,7 @@ def mail(recipient, subject, text, origin="seqmaster@scilifelab.se"):
 def mail_analysis(project_name, sample_name=None, engine_name=None,
                   level="ERROR", info_text=None, workflow=None,
                   recipient="ngi_pipeline_operators@scilifelab.se",
-                  subject=None, origin="seqmaster@scilifelab.se",
+                  subject=None, origin="ngi_pipeline@scilifelab.se",
                   config=None, config_file_path=None ):
 
     # check for mail recipient among the config values

--- a/ngi_pipeline/utils/communication.py
+++ b/ngi_pipeline/utils/communication.py
@@ -8,7 +8,7 @@ from ngi_pipeline.log.loggers import minimal_logger
 
 LOG = minimal_logger(__name__)
 
-def mail(recipient, subject, text, origin="seqmaster@scilifelab.se"):
+def mail(recipient, subject, text, origin="ngi_pipeline@scilifelab.se"):
     msg = MIMEText(text)
     msg['Subject'] = '[NGI_pipeline] {}'.format(subject)
     msg['From'] = origin


### PR DESCRIPTION
- Output is now written to `<base_root:>/<uppnexid_from_folder_struct>/<top_dir:>/` rather than the previous `/proj/<uppnexid_from_folder_struct>/<top_dir:>/`. Since `base_root` equals `/proj/` for the production installation anyway, this should cause no issues. It does however make running a staging or test version less "magical".

- NGI_Pipeline now correctly works with the UPPMAX's module installation of piper