### PR TITLE
Converting BAMs to FASTQ and preserving read group info

### DIFF
--- a/scripts/bam2fastq.sh
+++ b/scripts/bam2fastq.sh
@@ -58,6 +58,7 @@ fi
 # 1. shuffle the input bam
 # 2. run RevertSam to restore original qualities (if available)
 # 3. run SamToFastq to produce paired fastq files (readgroup information)
+
 samtools bamshuf -Ou "${IN}" "$SNIC_TMP/shuf.tmp" | \
 java -Xmx15G -jar "${PICARD_HOME}"/picard.jar RevertSam \
   INPUT=/dev/stdin \
@@ -77,10 +78,10 @@ java -Xmx15G -jar "${PICARD_HOME}"/picard.jar RevertSam \
 # should we consider INTERLEAVE=true ?
 
 # compress 
-gzip -v *fastq
+gzip -v $SNIC_TMP/*fastq
 
 # copy the results back from the node to the output directory
 if [ ! -z "$SLURM_JOB_ID" ]
 then
-  cp -v "$SNIC_TMP/*fastq.gz" "`dirname ${IN}`"
+  cp -v $SNIC_TMP/*fastq.gz `dirname ${IN}`
 fi

--- a/scripts/bam2fastq.sh
+++ b/scripts/bam2fastq.sh
@@ -30,7 +30,7 @@
 #SBATCH -n 4
 #SBATCH -N 1
 #SBATCH -J bam2fastq
-#SBATCH -t 24:00:00
+#SBATCH -t 48:00:00
 #SBATCH -o bam2fastq.%j.out
 #SBATCH -e bam2fastq.%j.err
 

--- a/scripts/bam2fastq.sh
+++ b/scripts/bam2fastq.sh
@@ -69,6 +69,7 @@ java -Xmx15G -jar "${PICARD_HOME}"/picard.jar RevertSam \
 |java -Xmx15G -jar "${PICARD_HOME}"/picard.jar SamToFastq \
   INPUT=/dev/stdin \
   OUTPUT_PER_RG=true \
+  RG_TAG=ID \
   OUTPUT_DIR=$SNIC_TMP \
   INCLUDE_NON_PF_READS=true \
   INCLUDE_NON_PRIMARY_ALIGNMENTS=false


### PR DESCRIPTION
@vezzi this way the read group information is preserved: tested on a smaller BAM file so far. 