### PR TITLE
conductor.classes: fixing uppercase name self.LOG

### DIFF
--- a/ngi_pipeline/conductor/classes.py
+++ b/ngi_pipeline/conductor/classes.py
@@ -35,7 +35,7 @@ class NGIAnalysis(object):
         try:
             return get_engine_for_bp(self.project, self.config, self.config_file_path)
         except (RuntimeError, CharonError) as e:
-            self.LOG.error('Cannot identify engine for project {} : {}'.format(self.project, e))
+            self.log.error('Cannot identify engine for project {} : {}'.format(self.project, e))
             return None
 
 


### PR DESCRIPTION
Running `ngi_pipeline_start.py analyze project L.Dalen_17_02` was getting the following exception:
(Figured out, that this project was not supposed to be BP-ed (panthera project), but still fixing the typo to process exception correctly)

```
2017-02-24 11:08:09,411 - ngi_pipeline.utils.filesystem - INFO - Adding fastq file "P7402_2004_S4_L004_R1_001.fastq.gz" to seqrun "170216_ST-E00198_0202_AHGVLWALXX"
Traceback (most recent call last):
  File "/lupus/ngi/production/v1.5/sw/anaconda/envs/NGI/bin/ngi_pipeline_start.py", line 313, in <module>
    generate_bqsr_bam=args.generate_bqsr_bam)
  File "/lupus/ngi/production/v1.5/sw/anaconda/envs/NGI/lib/python2.7/site-packages/ngi_pipeline/utils/classes.py", line 31, in __call__
    return self.f(**kwargs)
  File "/lupus/ngi/production/v1.5/sw/anaconda/envs/NGI/lib/python2.7/site-packages/ngi_pipeline/conductor/launchers.py", line 36, in launch_analysis
    generate_bqsr_bam=generate_bqsr_bam, log=LOG)
  File "/lupus/ngi/production/v1.5/sw/anaconda/envs/NGI/lib/python2.7/site-packages/ngi_pipeline/conductor/classes.py", line 32, in __init__
    self.engine=self.get_engine()
  File "/lupus/ngi/production/v1.5/sw/anaconda/envs/NGI/lib/python2.7/site-packages/ngi_pipeline/conductor/classes.py", line 38, in get_engine
    self.LOG.error('Cannot identify engine for project {} : {}'.format(self.project, e))
```
