### PR TITLE
FRESH --> STALE upon FC organisation

### DIFF
--- a/ngi_pipeline/database/classes.py
+++ b/ngi_pipeline/database/classes.py
@@ -50,7 +50,7 @@ class CharonSession(requests.Session):
                     headers=self._api_token_dict, timeout=3))
 
         self._project_params = ('projectid', 'name', 'status', 'best_practice_analysis',
-                                'sequencing_facility', 'delivery_status', 'delivery_token')
+                                'sequencing_facility', 'delivery_status', 'delivery_token', 'delivery_projects')
         self._project_reset_params = tuple(set(self._project_params) - \
                                            set(['projectid', 'name',
                                                 'best_practice_analysis',
@@ -58,7 +58,7 @@ class CharonSession(requests.Session):
         self._sample_params = ('sampleid', 'status', 'analysis_status', 'qc_status',
                                'genotype_status', 'genotype_concordance',
                                'total_autosomal_coverage', 'total_sequenced_reads',
-                               'delivery_status', 'duplication_pc', 'type', 'pair')
+                               'delivery_status', 'duplication_pc', 'type', 'pair','delivery_token', 'delivery_projects')
         self._sample_reset_params = tuple(set(self._sample_params) - \
                                           set(['sampleid', 'total_sequenced_reads']))
         self._libprep_params = ('libprepid', 'qc')
@@ -96,7 +96,7 @@ class CharonSession(requests.Session):
         return self.get(self.construct_charon_url('samples', projectid)).json()
 
     def project_update(self, projectid, name=None, status=None, best_practice_analysis=None,
-                       sequencing_facility=None, delivery_status=None, delivery_token=None):
+                       sequencing_facility=None, delivery_status=None, delivery_token=None, delivery_projects=None):
         l_dict = locals()
         data = { k: l_dict.get(k) for k in self._project_params if l_dict.get(k)}
         return self.put(self.construct_charon_url('project', projectid),
@@ -136,7 +136,7 @@ class CharonSession(requests.Session):
     def sample_update(self, projectid, sampleid, status=None, analysis_status=None,
                       qc_status=None, genotype_status=None,
                       genotype_concordance=None, total_autosomal_coverage=None,
-                      total_sequenced_reads=None, delivery_status=None, duplication_pc=None):
+                      total_sequenced_reads=None, delivery_status=None, duplication_pc=None, delivery_token=None, delivery_projects=None ):
         url = self.construct_charon_url("sample", projectid, sampleid)
         l_dict = locals()
         data = { k: l_dict.get(k) for k in self._sample_params if l_dict.get(k)}

--- a/ngi_pipeline/database/filesystem.py
+++ b/ngi_pipeline/database/filesystem.py
@@ -61,6 +61,7 @@ def create_charon_entries_from_project(project, best_practice_analysis="whole_ge
                 LOG.error('Could not delete sample "{}": {}'.format(sample, e))
         try:
             analysis_status = "TO_ANALYZE"
+            sample_data_status_value = "STALE"
             LOG.info('Creating sample "{}" with analysis_status "{}"'.format(sample, analysis_status))
             charon_session.sample_create(projectid=project.project_id,
                                          sampleid=sample.name,
@@ -73,9 +74,14 @@ def create_charon_entries_from_project(project, best_practice_analysis="whole_ge
                              'sample "{}"'.format(project, sample))
                     charon_session.sample_update(projectid=project.project_id,
                                                  sampleid=sample.name,
-                                                 analysis_status=analysis_status)
+                                                 analysis_status=analysis_status,
+                                                 status=sample_data_status_value)
                     LOG.info('Project/sample "{}/{}" updated in Charon.'.format(project, sample))
                 else:
+                    #update the status of the sample to STALE
+                    charon_session.sample_update(projectid=project.project_id,
+                                                 sampleid=sample.name,
+                                                 status=sample_data_status_value)
                     LOG.info('Project "{}" / sample "{}" already exists; moving '
                              'to libpreps'.format(project, sample))
             else:

--- a/ngi_pipeline/engines/piper_ngi/local_process_tracking.py
+++ b/ngi_pipeline/engines/piper_ngi/local_process_tracking.py
@@ -445,7 +445,7 @@ def record_process_sample(project, sample, workflow_subtask, analysis_module_nam
             sample_status_field = "analysis_status"
             sample_status_value = "UNDER_ANALYSIS"
             sample_data_status_field = "status"
-            sample_data_status_value = "STALE"
+            sample_data_status_value = '' #in his way it will not be updated
             seqrun_status_field = "alignment_status"
             seqrun_status_value = "RUNNING"
             extra_args = {"mean_autosomal_coverage": 0}

--- a/scripts/gt_concordance.py
+++ b/scripts/gt_concordance.py
@@ -154,6 +154,8 @@ def parse_xl_file(config, xl_file):
     data = data[1:]
     for row in data:
         # row[1] is always sample name. If doesn't match NGI format - skip.
+        if len(row) == 0:
+            continue
         if not re.match(r"^ID\d+-P\d+_\d+", row[1]):
             continue
         # sample has format ID22-P2655_176


### PR DESCRIPTION
Until now a sample was transitioning from FRESH to STALE when starting BP, but then this affected the status of samples that do not undergo BP (non WHG).
I changed the logic in such  a way that now samples become STALE when we organise them.

In Stockholm case if new data is produced ACHERON will set the status of a STALE sample to FRESH again and upon organisation the sample will become again STALE. 

This is the first of three PR for GRUS-delivery