### PR TITLE
Allow index file to be passed to QC step

### DIFF
--- a/ngi_pipeline/engines/qc_ngi/workflows.py
+++ b/ngi_pipeline/engines/qc_ngi/workflows.py
@@ -202,9 +202,6 @@ def fastq_to_be_analysed(fastq_files, analysis_dir, output_footers):
         if not m:
             # fastq file name doesn't match expected pattern -- let be serious.. we do NOT process it
             continue
-        if '_I1_' in fastq_file:
-            #Don't want to include index files in the QC. 10X specific 
-            continue 
         linked_fastq_file_base = '{}_{}'.format(m.groups()[0], fc_id)
         linked_fastq_file_name = '{}_{}.{}'.format( m.groups()[0], fc_id, m.groups()[1])
         linked_fastq_file_path = os.path.join(analysis_dir, linked_fastq_file_name)

--- a/ngi_pipeline/engines/qc_ngi/workflows.py
+++ b/ngi_pipeline/engines/qc_ngi/workflows.py
@@ -202,6 +202,9 @@ def fastq_to_be_analysed(fastq_files, analysis_dir, output_footers):
         if not m:
             # fastq file name doesn't match expected pattern -- let be serious.. we do NOT process it
             continue
+        if '_I1_' in fastq_file:
+            #Don't want to include index files in the QC. 10X specific 
+            continue 
         linked_fastq_file_base = '{}_{}'.format(m.groups()[0], fc_id)
         linked_fastq_file_name = '{}_{}.{}'.format( m.groups()[0], fc_id, m.groups()[1])
         linked_fastq_file_path = os.path.join(analysis_dir, linked_fastq_file_name)

--- a/ngi_pipeline/utils/parsers.py
+++ b/ngi_pipeline/utils/parsers.py
@@ -197,6 +197,7 @@ def find_fastq_read_pairs(file_list):
     suffix_pattern = re.compile(r'(.*)fastq')
     # Cut off at the read group
     file_format_pattern = re.compile(r'(.*)_(?:R\d|\d\.).*')
+    index_format_pattern= re.compile(r'(.*)_(?:I\d|\d\.).*')
     matches_dict = collections.defaultdict(list)
     for file_pathname in file_list:
         file_basename = os.path.basename(file_pathname)
@@ -206,13 +207,18 @@ def find_fastq_read_pairs(file_list):
             pair_base = file_format_pattern.match(file_basename).groups()[0]
             matches_dict["{}_{}".format(pair_base,fc_id)].append(file_pathname)
         except AttributeError:
-            LOG.warn("Warning: file doesn't match expected file format, "
+    
+            #look for index file - 10Xgenomics case
+            index_file = index_format_pattern.match(file_basename).groups()[0]
+            if index_file:
+                matches_dict["{}_{}".format(pair_base,fc_id)].append(file_pathname)
+            else:
+                LOG.warn("Warning: file doesn't match expected file format, "
                       "cannot be paired: \"{}\"".format(file_pathname))
-            # File could not be paired, set by itself (?)
-            file_basename_stripsuffix = suffix_pattern.split(file_basename)[0]
-            matches_dict[file_basename_stripsuffix].append(os.abspath(file_pathname))
+                # File could not be paired, set by itself (?)
+                file_basename_stripsuffix = suffix_pattern.split(file_basename)[0]
+                matches_dict[file_basename_stripsuffix].append(os.abspath(file_pathname))
     return dict(matches_dict)
-
 
 def parse_lane_from_filename(sample_basename):
     """Lane number is parsed from the standard filename format,

--- a/ngi_pipeline/utils/parsers.py
+++ b/ngi_pipeline/utils/parsers.py
@@ -211,7 +211,7 @@ def find_fastq_read_pairs(file_list):
             #look for index file - 10Xgenomics case
             index_file = index_format_pattern.match(file_basename).groups()[0]
             if index_file:
-                matches_dict["{}_{}".format(pair_base,fc_id)].append(file_pathname)
+                matches_dict["{}_{}".format(index_file,fc_id)].append(file_pathname)
             else:
                 LOG.warn("Warning: file doesn't match expected file format, "
                       "cannot be paired: \"{}\"".format(file_pathname))


### PR DESCRIPTION
I changed this PR since the original solution didn't work. The problem being that /ngi_pipeline/ngi_pipeline/utils/parsers.py was breaking before we even got to my fix. 

Thanks to the staging environment I was able to test and debug this. My new solution is simply to add the index files to the list of fastq files to analyse. I've tested this on project P7607 and it seems to work fine. 
![screen shot 2017-11-16 at 10 18 49](https://user-images.githubusercontent.com/16774076/32883417-a2f07c84-cab7-11e7-82b2-7f73a5517781.png)
 