### PR TITLE
determine libprep based on sample number, project id, sample name and…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
     - mkdir ~/.ngipipeline && cp test_ngi_config.yaml ~/.ngipipeline/ngi_config.yaml
 
 script:
-    - pytest --cov=ngi_pipeline ngi_pipeline/tests/engines/
+    - pytest --cov=ngi_pipeline ngi_pipeline/tests/engines/ ngi_pipeline/tests/conductor/ ngi_pipeline/utils/test_parsers.py
 
 after_success:
   - codecov

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ before_script:
     - mkdir ~/.ngipipeline && cp test_ngi_config.yaml ~/.ngipipeline/ngi_config.yaml
 
 script:
-    - pytest --cov=ngi_pipeline ngi_pipeline/tests/engines/ ngi_pipeline/tests/conductor/ ngi_pipeline/utils/test_parsers.py
+    - pytest --cov=ngi_pipeline ngi_pipeline/tests/engines/ ngi_pipeline/tests/conductor/ ngi_pipeline/tests/utils/test_parsers.py
 
 after_success:
   - codecov

--- a/ngi_pipeline/conductor/flowcell.py
+++ b/ngi_pipeline/conductor/flowcell.py
@@ -199,6 +199,9 @@ def match_fastq_sample_number_to_samplesheet(fastq_file, samplesheet_sample_numb
     except IndexError:
         # the sample number and lane number could not be matched to any samplesheet_sample_number
         pass
+    except TypeError:
+        # the list of samplesheet entries was None
+        pass
     return None
 
 

--- a/ngi_pipeline/tests/conductor/test_flowcell.py
+++ b/ngi_pipeline/tests/conductor/test_flowcell.py
@@ -1,0 +1,33 @@
+
+import unittest
+
+from ngi_pipeline.conductor.flowcell import match_fastq_sample_number_to_samplesheet
+
+
+class TestFlowcell(unittest.TestCase):
+
+    def test_match_fastq_sample_number_to_samplesheet(self):
+        test_samples = {
+            "S1": [["S1", "proj1", "sample-name", "", "", 1],
+                   ["S1", "proj1", "sample-name", "", "", 2],
+                   ["S1", "proj1", "sample-name", "", "", 3],
+                   ["S1", "proj1", "sample-name", "", "", 4]],
+            "S2": [["S2", "proj1", "sample-name", "", "", 1],
+                   ["S2", "proj1", "sample-name", "", "", 2]]
+        }
+        test_data = [
+            ["sample-name_S1_L001_R1_001.fastq.gz", test_samples["S1"]+test_samples["S2"], None, test_samples["S1"][0]],
+            ["sample-name_S1_L001_R1_001.fastq.gz", test_samples["S1"]+test_samples["S2"], "not-proj1", None],
+            ["sample-name_S1_L003_R1_001.fastq.gz", test_samples["S1"]+test_samples["S2"], None, test_samples["S1"][2]],
+            ["sample-name_S2_L002_R1_001.fastq.gz", test_samples["S1"]+test_samples["S2"], None, test_samples["S2"][1]],
+            ["not-sample-name_S2_L002_R1_001.fastq.gz", test_samples["S1"]+test_samples["S2"], None, None],
+            ["sample-name_S2_L003_R1_001.fastq.gz", test_samples["S1"]+test_samples["S2"], None, None],
+            ["sample-name_S3_L003_R1_001.fastq.gz", test_samples["S1"]+test_samples["S2"], None, None],
+            ["sample-name_S3_L004_R1_001.fastq.gz", [], None, None],
+            ["sample-name_S3_L004_R1_001.fastq.gz", [[]], None, None],
+            ["sample-name_SX_L004_R1_001.fastq.gz", test_samples["S1"] + test_samples["S2"], None, None]
+        ]
+        for test_item in test_data:
+            self.assertEqual(
+                test_item[3],
+                match_fastq_sample_number_to_samplesheet(test_item[0], test_item[1], test_item[2]))

--- a/ngi_pipeline/tests/conductor/test_flowcell.py
+++ b/ngi_pipeline/tests/conductor/test_flowcell.py
@@ -23,6 +23,7 @@ class TestFlowcell(unittest.TestCase):
             ["not-sample-name_S2_L002_R1_001.fastq.gz", test_samples["S1"]+test_samples["S2"], None, None],
             ["sample-name_S2_L003_R1_001.fastq.gz", test_samples["S1"]+test_samples["S2"], None, None],
             ["sample-name_S3_L003_R1_001.fastq.gz", test_samples["S1"]+test_samples["S2"], None, None],
+            ["sample-name_S3_L004_R1_001.fastq.gz", None, None, None],
             ["sample-name_S3_L004_R1_001.fastq.gz", [], None, None],
             ["sample-name_S3_L004_R1_001.fastq.gz", [[]], None, None],
             ["sample-name_SX_L004_R1_001.fastq.gz", test_samples["S1"] + test_samples["S2"], None, None]

--- a/ngi_pipeline/tests/utils/test_parsers.py
+++ b/ngi_pipeline/tests/utils/test_parsers.py
@@ -1,4 +1,5 @@
 import datetime
+import mock
 import os
 import random
 import tempfile
@@ -6,7 +7,8 @@ import unittest
 
 from ngi_pipeline.utils.parsers import get_flowcell_id_from_dirtree, parse_lane_from_filename, \
                                        find_fastq_read_pairs, find_fastq_read_pairs_from_dir, \
-                                       determine_library_prep_from_samplesheet
+                                       determine_library_prep_from_samplesheet, _get_and_trim_field_value, \
+                                        _get_libprepid_from_description, get_sample_numbers_from_samplesheet
 from ngi_pipeline.tests import generate_test_data as gtd
 
 class TestCommon(unittest.TestCase):
@@ -36,18 +38,18 @@ class TestCommon(unittest.TestCase):
         # Test list functionality
         file_list = [ "P123_456_AAAAAA_L001_R1_001.fastq.gz",
                       "P123_456_AAAAAA_L001_R2_001.fastq.gz",]
-        expected_output = {"P123_456_AAAAAA_L001": sorted(file_list) }
+        expected_output = {"P123_456_AAAAAA_L001_": sorted(file_list) }
         self.assertEqual(expected_output, find_fastq_read_pairs(file_list))
 
     def test_find_fastq_read_pairs_from_dir(self):
-        tmp_dir = tempfile.mkdtemp()
+        tmp_dir = tempfile.mkdtemp(suffix="_AFCID")
         file_list = map(lambda x: os.path.join(tmp_dir, x),
                     [ "P123_456_AAAAAA_L001_R1_001.fastq.gz",
                       "P123_456_AAAAAA_L001_R2_001.fastq.gz",])
         for file_name in file_list:
             # Touch the file
             open(os.path.join(tmp_dir, file_name), 'w').close()
-        expected_output = {"P123_456_AAAAAA_L001": file_list }
+        expected_output = {"P123_456_AAAAAA_L001_AFCID": file_list }
         produced_output = find_fastq_read_pairs_from_dir(tmp_dir)
         # This makes the test pass but is annoying
         produced_output = { k: sorted(v) for k,v in produced_output.items() }
@@ -86,3 +88,48 @@ class TestCommon(unittest.TestCase):
                                                                          project_id="YM01",
                                                                          sample_id="Sample_CEP-NA10860-PCR-free,",
                                                                          lane_num=2)
+
+    def test__get_and_trim_field_value(self):
+        test_dict = {
+            "key1": "this-is-value1",
+            "key2": "this-is-value2",
+            "key3": "this-is-value3"
+        }
+        test_fields = sorted(test_dict.keys())
+        self.assertEqual(_get_and_trim_field_value(test_dict, test_fields), test_dict[test_fields[0]])
+        self.assertEqual(
+            _get_and_trim_field_value(test_dict, ["key-does-not-match"] + test_fields),
+            test_dict[test_fields[0]])
+        self.assertEqual(
+            _get_and_trim_field_value(test_dict, test_fields, "-is-"),
+            test_dict[test_fields[0]].replace("-is-", ""))
+        self.assertEqual(
+            _get_and_trim_field_value(test_dict, test_fields, "string-does-not-match"),
+            test_dict[test_fields[0]])
+        self.assertIsNone(_get_and_trim_field_value(test_dict, ["key-does-not-match"]))
+
+    def test__get_libprepid_from_description(self):
+        self.assertIsNone(_get_libprepid_from_description("this;is;a;description"))
+        self.assertEqual(_get_libprepid_from_description("this;is;a;description;LIBRARY_NAME:"), "")
+        self.assertEqual(
+            _get_libprepid_from_description("this:is;a:description;LIBRARY_NAME:this-is-the-libprepid;suffix"),
+            "this-is-the-libprepid")
+
+    def test_get_sample_numbers_from_samplesheet(self):
+        samplesheet_header = "Lane,Sample_ID,Sample_Name,Sample_Plate,Sample_Well,I7_Index_ID,index,Sample_Project," \
+                             "Description".split(",")
+        samplesheet_samples = [
+            "1,Sample_CEP-NA10860-PCR-free,CEP-NA10860-PCR-free,,,,AGTTCC,YM01,LIBRARY_NAME:CEP_Pool8".split(","),
+            "2,Sample_CEP-NA11992-PCR-free,CEP-NA11992-PCR-free,,,,ATGTCA,YM01,LIBRARY_NAME:CEP_Pool9".split(","),
+            "3,Sample_CEP-NA10860-PCR-free,CEP-NA10860-PCR-free,,,,AGTTCC,YM01,LIBRARY_NAME:CEP_Pool8".split(","),
+            "4,Sample_CEP-NA10860-PCR-free,CEP-NA10860-PCR-free,,,,GGTTCC,YM01,LIBRARY_NAME:CEP_Pool1".split(","),
+            "4,Sample_CEP-NA10860-PCR-free,CEP-NA10860-PCR-free,,,,GGTTCC,YM01,LIBRARY_NAME:CEP_Pool11".split(",")
+        ]
+        samplesheet_rows = [dict(zip(samplesheet_header, sample)) for sample in samplesheet_samples]
+        for row in samplesheet_rows[0:-1]:
+            row["index2"] = "TGCGTT"
+
+        with mock.patch('ngi_pipeline.utils.parsers.parse_samplesheet') as samplesheet_mock:
+            samplesheet_mock.return_value = samplesheet_rows
+            observed_sample_numbers = get_sample_numbers_from_samplesheet("samplesheet_path")
+            self.assertListEqual(["S1", "S2", "S1", "S3", "S4"], [osn[0] for osn in observed_sample_numbers])


### PR DESCRIPTION
… lane number

This PR introduces a modification so that the libprep id will be properly picked up from the samplesheet for SNP&SEQ. Currently, the libprep will not be properly recognized in case the same sample occurs multiple times (with different barcodes) in the same lane. This is now fixed so that the organise code will try to match the sample number in the fastq file to the entry in the sample sheet.