### PR TITLE
LOG.warn -> LOG.warning

### DIFF
--- a/ngi_pipeline/conductor/flowcell.py
+++ b/ngi_pipeline/conductor/flowcell.py
@@ -261,7 +261,7 @@ def setup_analysis_directory_structure(fc_dir, projects_to_analyze,
         return []
     fc_full_id = fc_dir_structure['fc_full_id']
     if not fc_dir_structure.get('projects'):
-        LOG.warn("No projects found in specified flowcell directory \"{}\"".format(fc_dir))
+        LOG.warning("No projects found in specified flowcell directory \"{}\"".format(fc_dir))
 
     # Iterate over the projects in the flowcell directory
     for project in fc_dir_structure.get('projects', []):
@@ -277,7 +277,7 @@ def setup_analysis_directory_structure(fc_dir, projects_to_analyze,
             # Maps e.g. "Y.Mom_14_01" to "P123"
             project_id = get_project_id_from_name(project_name)
         except (CharonError, RuntimeError, ValueError) as e:
-            LOG.warn('Could not retrieve project id from Charon (record missing?). '
+            LOG.warning('Could not retrieve project id from Charon (record missing?). '
                      'Using project name ("{}") as project id '
                      '(error: {})'.format(project_name, e))
             project_id = project_name
@@ -350,7 +350,7 @@ def setup_analysis_directory_structure(fc_dir, projects_to_analyze,
                         libpreps = charon_session.sample_get_libpreps(project_id, sample_name).get('libpreps')
                         if len(libpreps) == 1:
                             libprep_name = libpreps[0].get('libprepid')
-                            LOG.warn('Project "{}" / sample "{}" / seqrun "{}" / fastq "{}" '
+                            LOG.warning('Project "{}" / sample "{}" / seqrun "{}" / fastq "{}" '
                                      'has no libprep information in Charon, but only one '
                                      'library prep is present in Charon ("{}"). Using '
                                      'this as the library prep.'.format(project_name,
@@ -360,7 +360,7 @@ def setup_analysis_directory_structure(fc_dir, projects_to_analyze,
                                                                         libprep_name))
                         elif fallback_libprep:
                             libprep_name = fallback_libprep
-                            LOG.warn('Project "{}" / sample "{}" / seqrun "{}" / fastq "{}" '
+                            LOG.warning('Project "{}" / sample "{}" / seqrun "{}" / fastq "{}" '
                                      'has no libprep information in Charon, but a fallback '
                                      'libprep value of "{}" was supplied -- using this '
                                      'value.'.format(project_name,
@@ -441,7 +441,7 @@ def parse_flowcell(fc_dir):
     LOG.info('Parsing flowcell directory "{}"...'.format(fc_dir))
     samplesheet_path = os.path.join(fc_dir, "SampleSheet.csv")
     if not os.path.exists(samplesheet_path):
-        LOG.warn("Could not find samplesheet in directory {}".format(fc_dir))
+        LOG.warning("Could not find samplesheet in directory {}".format(fc_dir))
         samplesheet_path = None
     else:
         LOG.debug("SampleSheet.csv found at {}".format(samplesheet_path))
@@ -477,7 +477,7 @@ def parse_flowcell(fc_dir):
                                     'sample_name': sample_name,
                                     'files': fastq_files})
         if not project_samples:
-            LOG.warn('No samples found for project "{}" in fc "{}"'.format(project_name, fc_dir))
+            LOG.warning('No samples found for project "{}" in fc "{}"'.format(project_name, fc_dir))
         else:
             projects.append({'data_dir': os.path.relpath(os.path.dirname(project_dir), fc_dir),
                              'project_dir': os.path.basename(project_dir),

--- a/ngi_pipeline/database/filesystem.py
+++ b/ngi_pipeline/database/filesystem.py
@@ -39,7 +39,7 @@ def create_charon_entries_from_project(project, best_practice_analysis="whole_ge
     except CharonError as e:
         if e.status_code == 400:
             if force_overwrite:
-                LOG.warn('Overwriting data for project "{}"'.format(project))
+                LOG.warning('Overwriting data for project "{}"'.format(project))
                 charon_session.project_update(projectid=project.project_id,
                                               name=project.name,
                                               status=status,
@@ -52,7 +52,7 @@ def create_charon_entries_from_project(project, best_practice_analysis="whole_ge
             raise
     for sample in project:
         if delete_existing:
-            LOG.warn('Deleting existing sample "{}"'.format(sample))
+            LOG.warning('Deleting existing sample "{}"'.format(sample))
             try:
                 charon_session.sample_delete(projectid=project.project_id,
                                              sampleid=sample.name)
@@ -70,7 +70,7 @@ def create_charon_entries_from_project(project, best_practice_analysis="whole_ge
         except CharonError as e:
             if e.status_code == 400:
                 if force_overwrite:
-                    LOG.warn('Overwriting data for project "{}" / '
+                    LOG.warning('Overwriting data for project "{}" / '
                              'sample "{}"'.format(project, sample))
                     charon_session.sample_update(projectid=project.project_id,
                                                  sampleid=sample.name,
@@ -90,13 +90,13 @@ def create_charon_entries_from_project(project, best_practice_analysis="whole_ge
                 continue
         for libprep in sample:
             if delete_existing:
-                LOG.warn('Deleting existing libprep "{}"'.format(libprep))
+                LOG.warning('Deleting existing libprep "{}"'.format(libprep))
                 try:
                     charon_session.libprep_delete(projectid=project.project_id,
                                                   sampleid=sample.name,
                                                   libprepid=libprep.name)
                 except CharonError as e:
-                    LOG.warn('Could not delete libprep "{}": {}'.format(libprep, e))
+                    LOG.warning('Could not delete libprep "{}": {}'.format(libprep, e))
             try:
                 qc = "PASSED"
                 LOG.info('Creating libprep "{}" with qc status "{}"'.format(libprep, qc))
@@ -109,7 +109,7 @@ def create_charon_entries_from_project(project, best_practice_analysis="whole_ge
             except CharonError as e:
                 if e.status_code == 400:
                     if force_overwrite:
-                        LOG.warn('Overwriting data for project "{}" / '
+                        LOG.warning('Overwriting data for project "{}" / '
                                  'sample "{}" / libprep "{}"'.format(project, sample,
                                                                      libprep))
                         charon_session.libprep_update(projectid=project.project_id,
@@ -128,7 +128,7 @@ def create_charon_entries_from_project(project, best_practice_analysis="whole_ge
                     continue
             for seqrun in libprep:
                 if delete_existing:
-                    LOG.warn('Deleting existing seqrun "{}"'.format(seqrun))
+                    LOG.warning('Deleting existing seqrun "{}"'.format(seqrun))
                     try:
                         charon_session.seqrun_delete(projectid=project.project_id,
                                                      sampleid=sample.name,
@@ -153,7 +153,7 @@ def create_charon_entries_from_project(project, best_practice_analysis="whole_ge
                 except CharonError as e:
                     if e.status_code == 400:
                         if force_overwrite:
-                            LOG.warn('Overwriting data for project "{}" / '
+                            LOG.warning('Overwriting data for project "{}" / '
                                      'sample "{}" / libprep "{}" / '
                                      'seqrun "{}"'.format(project, sample,
                                                           libprep, seqrun))

--- a/ngi_pipeline/database/local_process_tracking.py
+++ b/ngi_pipeline/database/local_process_tracking.py
@@ -82,7 +82,7 @@ def check_update_jobs_status(projects_to_check=None, config=None, config_file_pa
                     LOG.error(e)
                     continue
             except RuntimeError as e:
-                LOG.warn(e)
+                LOG.warning(e)
                 continue
         else:
             ## FIXME

--- a/ngi_pipeline/engines/bcbio_ngi/__init__.py
+++ b/ngi_pipeline/engines/bcbio_ngi/__init__.py
@@ -40,7 +40,7 @@ LAUNCH_METHODS = (
 
 def launch_pipeline(run_config, launch_method):
     if launch_method.lower() not in LAUNCH_METHODS:
-        LOG.warn("Launch method \"{}\" not available for run config {}. "\
+        LOG.warning("Launch method \"{}\" not available for run config {}. "\
                  "Valid choices are: {}".format(launch_method, run_config,
                                                 ", ".join(LAUNCH_METHODS)))
         return None
@@ -253,7 +253,7 @@ def build_run_configs(samples_dir=None, config_path=None, output_dir=None, uploa
             project_id = get_project_id_from_filename(sample_basename)
         except ValueError as e:
             # Could not determine project id
-            LOG.warn(e)
+            LOG.warning(e)
             continue
         if not output_dir:
             output_dir = os.path.join(os.path.dirname(os.path.abspath(sample_files[0])), "project_{}".format(sample_basename))

--- a/ngi_pipeline/engines/piper_ngi/command_creation_config.py
+++ b/ngi_pipeline/engines/piper_ngi/command_creation_config.py
@@ -93,7 +93,7 @@ def build_setup_xml(project, sample, workflow, local_scratch_mode, config):
         charon_project = charon_session.project_get(project.project_id)
         cl_args["sequencing_center"] = charon_project["sequencing_facility"]
     except (KeyError, CharonError) as e:
-        LOG.warn('Could not determine sequencing center from Charon ({}); setting to "Unknown".'.format(e))
+        LOG.warning('Could not determine sequencing center from Charon ({}); setting to "Unknown".'.format(e))
         cl_args["sequencing_center"] = "Unknown"
     cl_args["sequencing_tech"] = "Illumina"
     slurm_qos = config.get("slurm", {}).get("extra_params", {}).get("--qos")

--- a/ngi_pipeline/engines/piper_ngi/launchers.py
+++ b/ngi_pipeline/engines/piper_ngi/launchers.py
@@ -73,7 +73,7 @@ def analyze(analysis_object, level='sample', config=None, config_file_path=None)
         elif level == "genotype":
             status_field = "genotype_status"
         else:
-            LOG.warn('Unknown workflow level: "{}"'.format(level))
+            LOG.warning('Unknown workflow level: "{}"'.format(level))
             status_field = "alignment_status" # Or should we abort?
         try:
             check_for_preexisting_sample_runs(analysis_object.project, sample, analysis_object.restart_running_jobs,

--- a/ngi_pipeline/engines/piper_ngi/local_process_tracking.py
+++ b/ngi_pipeline/engines/piper_ngi/local_process_tracking.py
@@ -232,7 +232,7 @@ def update_charon_with_local_jobs_status(quiet=False, config=None, config_file_p
                             remote_sample=charon_session.sample_get(projectid=project_id, sampleid=sample_id)
                             charon_status = remote_sample.get(sample_status_field)
                             if charon_status and not charon_status == set_status:
-                                LOG.warn('Tracking inconsistency for {}: Charon status '
+                                LOG.warning('Tracking inconsistency for {}: Charon status '
                                          'for field "{}" is "{}" but local process tracking '
                                          'database indicates it is running. Setting value '
                                          'in Charon to {}.'.format(label, sample_status_field,
@@ -429,7 +429,7 @@ def record_process_sample(project, sample, workflow_subtask, analysis_module_nam
                              'workflow "{}"'.format(slurm_job_id, project, sample, workflow_subtask))
                     break
                 except OperationalError as e:
-                    LOG.warn('Database locked ("{}"). Waiting...'.format(e))
+                    LOG.warning('Database locked ("{}"). Waiting...'.format(e))
                     time.sleep(15)
             else:
                 raise RuntimeError("Could not write to database after three attempts (locked?)")

--- a/ngi_pipeline/engines/piper_ngi/utils.py
+++ b/ngi_pipeline/engines/piper_ngi/utils.py
@@ -116,7 +116,7 @@ def remove_previous_genotype_analyses(project_obj):
             except OSError as e:
                 errors.append("{}: {}".format(sample_file, e))
         if errors:
-            LOG.warn("Error when removing one or more files: {}".format("\n".join(errors)))
+            LOG.warning("Error when removing one or more files: {}".format("\n".join(errors)))
     else:
         LOG.debug('No genotype analysis files found to delete for project {} '
                   '/ samples {}'.format(project_obj, ", ".join(project_obj.samples)))
@@ -147,7 +147,7 @@ def remove_previous_sample_analyses(project_obj, sample_obj=None):
             except OSError as e:
                 errors.append("{}: {}".format(sample_file, e))
         if errors:
-            LOG.warn("Error when removing one or more files: {}".format("\n".join(errors)))
+            LOG.warning("Error when removing one or more files: {}".format("\n".join(errors)))
     else:
         LOG.debug('No sample analysis files found to delete for project {} '
                   '/ samples {}'.format(project_obj, ", ".join(project_obj.samples)))

--- a/ngi_pipeline/engines/piper_ngi/workflows.py
+++ b/ngi_pipeline/engines/piper_ngi/workflows.py
@@ -130,7 +130,7 @@ def workflow_dna_variantcalling(qscripts_dir_path, setup_xml_path,
     if job_native_args:
         # This should be a list
         if type(job_native_args) is not list:
-            LOG.warn('jobNative arguments in config file specified in invalid '
+            LOG.warning('jobNative arguments in config file specified in invalid '
                      'format; should be list. Ignoring these parameters.')
         else:
             cl_string += " -jobNative {}".format(" ".join(job_native_args))

--- a/ngi_pipeline/engines/qc_ngi/launchers.py
+++ b/ngi_pipeline/engines/qc_ngi/launchers.py
@@ -62,7 +62,7 @@ def analyze(project, sample, quiet=False, config=None, config_file_path=None):
             with open(slurm_jobid_file, 'w') as f:
                 f.write("{}\n".format(slurm_job_id))
         except IOError as e:
-            LOG.warn('Could not write slurm job id for project/sample '
+            LOG.warning('Could not write slurm job id for project/sample '
                      '{}/{} to file "{}" ({}). So... yup. Good luck bro!'.format(e))
 
 

--- a/ngi_pipeline/engines/qc_ngi/workflows.py
+++ b/ngi_pipeline/engines/qc_ngi/workflows.py
@@ -134,7 +134,7 @@ def workflow_fastq_screen(input_files, output_dir, config):
     fastq_screen_config_path = config.get("qc", {}).get("fastq_screen", {}).get("config_path")
     # We probably should have the path to the fastq_screen config file written down somewhere
     if not fastq_screen_config_path:
-        LOG.warn('Path to fastq_screen config file not specified; assuming '
+        LOG.warning('Path to fastq_screen config file not specified; assuming '
                  'it is in the same directory as the fastq_screen binary, '
                  'even though I think this is probably a fairly bad '
                  'assumption to make. You\'re in charge, whatever.')

--- a/ngi_pipeline/utils/charon.py
+++ b/ngi_pipeline/utils/charon.py
@@ -197,8 +197,8 @@ def find_projects_from_samples(sample_list):
             else:
                 projects_dict[owner_projects_list[0]].add(sample_name)
     if no_owners_found:
-        LOG.warn("No projects found for the following samples: {}".format(", ".join(no_owners_found)))
+        LOG.warning("No projects found for the following samples: {}".format(", ".join(no_owners_found)))
     if multiple_owners_found:
-        LOG.warn('Multiple projects found with the following samples (owner '
+        LOG.warning('Multiple projects found with the following samples (owner '
                  'could not be unamibugously determined): {}'.format(", ".join(multiple_owners_found)))
     return dict(projects_dict)

--- a/ngi_pipeline/utils/filesystem.py
+++ b/ngi_pipeline/utils/filesystem.py
@@ -143,7 +143,7 @@ def execute_command_line(cl, shell=False, stdout=None, stderr=None, cwd=None):
     :raises RuntimeError: If the OS command-line execution failed.
     """
     if cwd and not os.path.isdir(cwd):
-        LOG.warn("CWD specified, \"{}\", is not a valid directory for "
+        LOG.warning("CWD specified, \"{}\", is not a valid directory for "
                  "command \"{}\". Setting to None.".format(cwd, cl))
         ## FIXME Better to just raise an exception
         cwd = None
@@ -322,7 +322,7 @@ def recreate_project_from_filesystem(project_dir,
     samples_pattern = os.path.join(real_project_dir, "*")
     samples = filter(os.path.isdir, glob.glob(samples_pattern))
     if not samples:
-        LOG.warn('No samples found for project "{}"'.format(project_obj))
+        LOG.warning('No samples found for project "{}"'.format(project_obj))
     for sample_dir in samples:
         sample_name = os.path.basename(sample_dir)
         if restrict_to_samples and sample_name not in restrict_to_samples:
@@ -335,7 +335,7 @@ def recreate_project_from_filesystem(project_dir,
         libpreps_pattern = os.path.join(sample_dir, "*")
         libpreps = filter(os.path.isdir, glob.glob(libpreps_pattern))
         if not libpreps:
-            LOG.warn('No libpreps found for sample "{}"'.format(sample_obj))
+            LOG.warning('No libpreps found for sample "{}"'.format(sample_obj))
         for libprep_dir in libpreps:
             libprep_name = os.path.basename(libprep_dir)
             if restrict_to_libpreps and libprep_name not in restrict_to_libpreps:
@@ -349,7 +349,7 @@ def recreate_project_from_filesystem(project_dir,
             seqruns_pattern = os.path.join(libprep_dir, "*_*_*_*")
             seqruns = filter(os.path.isdir, glob.glob(seqruns_pattern))
             if not seqruns:
-                LOG.warn('No seqruns found for libprep "{}"'.format(libprep_obj))
+                LOG.warning('No seqruns found for libprep "{}"'.format(libprep_obj))
             for seqrun_dir in seqruns:
                 seqrun_name = os.path.basename(seqrun_dir)
                 if restrict_to_seqruns and seqrun_name not in restrict_to_seqruns:
@@ -397,7 +397,7 @@ def match_files_under_dir(dirname, pattern, pt_style="regex", realpath=True):
     :rtype: list
     """
     if pt_style not in ("regex", "shell"):
-        LOG.warn('Chosen pattern style "{}" invalid (must be "regex" or "shell"); '
+        LOG.warning('Chosen pattern style "{}" invalid (must be "regex" or "shell"); '
                  'falling back to "regex".')
         pt_style = "regex"
     if pt_style == "regex": pt_comp = re.compile(pattern)

--- a/ngi_pipeline/utils/parsers.py
+++ b/ngi_pipeline/utils/parsers.py
@@ -268,7 +268,7 @@ def find_fastq_read_pairs(file_list):
     file_list = filter(pt.match, file_list)
     if not file_list:
         # No files found
-        LOG.warn("No fastq files found.")
+        LOG.warning("No fastq files found.")
         return {}
     # --> This is the SciLifeLab-Sthlm-specific format (obsolete as of August 1st, hopefully)
     #     Format: <lane>_<date>_<flowcell>_<project-sample>_<read>.fastq.gz
@@ -295,7 +295,7 @@ def find_fastq_read_pairs(file_list):
             if index_file:
                 matches_dict["{}_{}".format(index_file,fc_id)].append(file_pathname)
             else:
-                LOG.warn("Warning: file doesn't match expected file format, "
+                LOG.warning("Warning: file doesn't match expected file format, "
                       "cannot be paired: \"{}\"".format(file_pathname))
                 # File could not be paired, set by itself (?)
                 file_basename_stripsuffix = suffix_pattern.split(file_basename)[0]

--- a/scripts/ngi_pipeline_start.py
+++ b/scripts/ngi_pipeline_start.py
@@ -499,7 +499,7 @@ if __name__ == "__main__":
                     path_to_project = locate_project(project_id)
                 except ValueError:
                     # Project has not yet been organized from flowcell level
-                    LOG.warn('Project "{}" has not yet been organized from '
+                    LOG.warning('Project "{}" has not yet been organized from '
                              'flowcell to project level; skipping.'.format(project_id))
                     continue
                 project = recreate_project_from_filesystem(project_dir=path_to_project,


### PR DESCRIPTION
This PR changes all of occurrences of `LOG.warn` to `LOG.warning`. `warn` is not a function of `logging` and would therefore make the pipeline crash. 