### PR TITLE
Feature/sarek folder structure

### DIFF
--- a/ngi_pipeline/engines/sarek/models/sarek.py
+++ b/ngi_pipeline/engines/sarek/models/sarek.py
@@ -434,7 +434,7 @@ class SarekGermlineAnalysis(SarekAnalysis):
         return [SarekPreprocessingStep(
             *step_args, sample=analysis_sample.sample_analysis_tsv_file(), **local_sarek_config)] + map(
             lambda step: step(*step_args, **local_sarek_config),
-            [SarekGermlineVCStep, SarekAnnotateStep, SarekMultiQCStep])
+            [SarekGermlineVCStep, SarekAnnotateStep])
 
     def command_line(self, analysis_sample):
         """

--- a/ngi_pipeline/engines/sarek/process.py
+++ b/ngi_pipeline/engines/sarek/process.py
@@ -177,7 +177,7 @@ class SlurmConnector(ProcessConnector):
     """
 
     # a boilerplate template for the SLURM job header
-    JOB_HEADER_TEMPLATE = """#! /bin/bash
+    JOB_HEADER_TEMPLATE = """#! /bin/bash -l
 
 #SBATCH -A {slurm_project}
 #SBATCH -J "{slurm_job_name}"

--- a/ngi_pipeline/engines/sarek/process.py
+++ b/ngi_pipeline/engines/sarek/process.py
@@ -240,8 +240,10 @@ class SlurmConnector(ProcessConnector):
         :return: the path to the created SLURM script
         """
         # create the script in the passed working directory
+        slurm_script_dir = os.path.join(working_dir, "sbatch")
+        safe_makedir(slurm_script_dir)
         slurm_script = os.path.join(
-            working_dir, "{}.{}.sbatch".format(job_name, datetime.datetime.now().strftime("%s")))
+            slurm_script_dir, "{}.{}.sbatch".format(job_name, datetime.datetime.now().strftime("%s")))
         slurm_stdout = "{}.out".format(slurm_script)
         slurm_stderr = "{}.err".format(slurm_script)
 

--- a/ngi_pipeline/tests/engines/sarek/test_process.py
+++ b/ngi_pipeline/tests/engines/sarek/test_process.py
@@ -201,13 +201,7 @@ class TestSlurmConnector(unittest.TestCase):
         expected_command_line = "this-is-a-command-line"
         expected_exit_code_path = "this-is-the-exit-code-path"
         expected_job_name = "test_slurm_job"
-
-        # a non-existing working dir will result in an exception
-        expected_working_dir = os.path.join(self.cwd, "this-folder-does-not-exist")
-        with self.assertRaises(IOError) as ioe:
-            self.slurm_connector._slurm_script_from_command_line(
-                expected_command_line, expected_working_dir, expected_exit_code_path, expected_job_name)
-            self.assertEqual(errno.ENOENT, ioe.exception.errno)
+        expected_script_dir = os.path.join(self.cwd, "sbatch")
 
         expected_prefix = "mock_prefix"
         expected_script_name = "{}.{}.sbatch".format(expected_job_name, expected_prefix)
@@ -216,6 +210,5 @@ class TestSlurmConnector(unittest.TestCase):
             observed_script = self.slurm_connector._slurm_script_from_command_line(
                 expected_command_line, self.cwd, expected_exit_code_path, expected_job_name)
             self.assertTrue(os.path.exists(observed_script))
-            self.assertEqual(self.cwd, os.path.dirname(observed_script))
+            self.assertEqual(expected_script_dir, os.path.dirname(observed_script))
             self.assertEqual(expected_script_name, os.path.basename(observed_script))
-


### PR DESCRIPTION
- use a subdirectory for sbatch script and output
- load the bashrc from sbatch files after all, nextflow uses a lot of environment variables which will be more consistently set up this way
- don't run multiqc as part of the single-sample analysis
