### PR TITLE
continue updating charon status even if a sample raises exception

### DIFF
--- a/ngi_pipeline/engines/sarek/local_process_tracking.py
+++ b/ngi_pipeline/engines/sarek/local_process_tracking.py
@@ -57,7 +57,6 @@ def update_charon_with_local_jobs_status(
         except Exception as e:
             log.error("exception raised when processing sample {} in project {}, please review: {}".format(
                 analysis.project_id, analysis.sample_id, e))
-            raise
 
 
 class AnalysisTracker(object):


### PR DESCRIPTION
a raised exception during local db to charon sync will not break the iteration