### PR TITLE
remove barcode from sample number logic

### DIFF
--- a/ngi_pipeline/tests/utils/test_parsers.py
+++ b/ngi_pipeline/tests/utils/test_parsers.py
@@ -132,4 +132,4 @@ class TestCommon(unittest.TestCase):
         with mock.patch('ngi_pipeline.utils.parsers.parse_samplesheet') as samplesheet_mock:
             samplesheet_mock.return_value = samplesheet_rows
             observed_sample_numbers = get_sample_numbers_from_samplesheet("samplesheet_path")
-            self.assertListEqual(["S1", "S2", "S1", "S3", "S4"], [osn[0] for osn in observed_sample_numbers])
+            self.assertListEqual(["S1", "S2", "S1", "S1", "S1"], [osn[0] for osn in observed_sample_numbers])

--- a/ngi_pipeline/utils/parsers.py
+++ b/ngi_pipeline/utils/parsers.py
@@ -178,7 +178,7 @@ def get_sample_numbers_from_samplesheet(samplesheet_path):
         ss_lane_num = int(_get_and_trim_field_value(row, ["Lane"]))
         ss_libprepid = _get_libprepid_from_description(
             _get_and_trim_field_value(row, ["Description"]))
-        fingerprint = "-".join([ss_project_id, ss_sample_id, ss_barcode])
+        fingerprint = "-".join([ss_project_id, ss_sample_id])
         if fingerprint not in seen_samples:
             seen_samples.append(fingerprint)
         ss_sample_number = seen_samples.index(fingerprint) + 1


### PR DESCRIPTION
In Uppsala, we have the library prep information in the sample sheet and need to match the Fastq file to the sample sheet entry in order to retrieve it. This corrects the logic for doing that so that the sample id is the only field determining the sample number.