### PR TITLE
Fix path to bamqc results

### DIFF
--- a/ngi_pipeline/engines/sarek/models/workflow.py
+++ b/ngi_pipeline/engines/sarek/models/workflow.py
@@ -118,7 +118,7 @@ class SarekPreprocessingStep(SarekWorkflowStep):
         return [
             [
                 QualiMapParser,
-                os.path.join(report_dir, "bamQC", analysis_sample.sampleid, "genome_results.txt")],
+                os.path.join(report_dir, "bamQC", "{}.recal".format(analysis_sample.sampleid), "genome_results.txt")],
             [
                 PicardMarkDuplicatesParser,
                 os.path.join(markdups_dir, markdups_metrics_file)]]

--- a/ngi_pipeline/engines/sarek/process.py
+++ b/ngi_pipeline/engines/sarek/process.py
@@ -197,7 +197,7 @@ class SlurmConnector(ProcessConnector):
         "slurm_partition": "core",
         "slurm_nodes": 1,
         "slurm_cores": 1,
-        "slurm_job_time": "48:00:00",
+        "slurm_job_time": "72:00:00",
         "slurm_mail_events": "NONE"
     }
 

--- a/ngi_pipeline/tests/utils/test_parsers.py
+++ b/ngi_pipeline/tests/utils/test_parsers.py
@@ -132,4 +132,4 @@ class TestCommon(unittest.TestCase):
         with mock.patch('ngi_pipeline.utils.parsers.parse_samplesheet') as samplesheet_mock:
             samplesheet_mock.return_value = samplesheet_rows
             observed_sample_numbers = get_sample_numbers_from_samplesheet("samplesheet_path")
-            self.assertListEqual(["S1", "S2", "S1", "S3", "S4"], [osn[0] for osn in observed_sample_numbers])
+            self.assertListEqual(["S1", "S2", "S1", "S1", "S1"], [osn[0] for osn in observed_sample_numbers])

--- a/ngi_pipeline/utils/parsers.py
+++ b/ngi_pipeline/utils/parsers.py
@@ -178,7 +178,7 @@ def get_sample_numbers_from_samplesheet(samplesheet_path):
         ss_lane_num = int(_get_and_trim_field_value(row, ["Lane"]))
         ss_libprepid = _get_libprepid_from_description(
             _get_and_trim_field_value(row, ["Description"]))
-        fingerprint = "-".join([ss_project_id, ss_sample_id, ss_barcode])
+        fingerprint = "-".join([ss_project_id, ss_sample_id])
         if fingerprint not in seen_samples:
             seen_samples.append(fingerprint)
         ss_sample_number = seen_samples.index(fingerprint) + 1


### PR DESCRIPTION
This PR updates the path to the QualiMap result file which changed in Sarek 2.3. The default slurm time allocation for the cextflow control job was increased to 72h (could be needed for higher coverage samples). In addition, a fix to the logic matching the samplesheet rows to the fastq filename index, assigned by bcl2fastq was supplied.
