### PR TITLE
Update req to keep supporting py2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 click
 CouchDB>=0.9
 coverage>=3.7.1
-inflect>=0.2.5
+inflect>=0.2.5,<=3.0.2 #Versions greater than 3.0.2 don't support py2.7, remove upper limit when py3 migration is complete
 psutil>=2.1.1
 pyexcel<=0.5.15
 pyexcel-xlsx


### PR DESCRIPTION
Found this when Travis started failing for taca-ngi-pipeline which has a dependency on ngi-pipeline.