### PR TITLE
Batch sarek analyses

### DIFF
--- a/ngi_pipeline/conductor/classes.py
+++ b/ngi_pipeline/conductor/classes.py
@@ -152,7 +152,7 @@ def get_engine_for_bp(project, config=None, config_file_path=None):
         best_practice_analysis = charon_session.project_get(project.project_id)["best_practice_analysis"]
     except KeyError:
         error_msg = ('No best practice analysis specified in Charon for '
-                     'project "{}". Using "whole_genome_reseq"'.format(project))
+                     'project "{}". Using "wgs_germline"'.format(project))
         raise RuntimeError(error_msg)
     try:
         analysis_module = load_engine_module(best_practice_analysis, config)

--- a/ngi_pipeline/conductor/classes.py
+++ b/ngi_pipeline/conductor/classes.py
@@ -9,7 +9,7 @@ from six.moves import zip
 class NGIAnalysis(object):
     def __init__(self, project, restart_failed_jobs=None,
                     restart_finished_jobs=False, restart_running_jobs=False,
-                    no_qc=False, exec_mode="sbatch",
+                    no_qc=False, exec_mode="sbatch", batch_analysis=False,
                     quiet=False, manual=False, config=None, config_file_path=None,
                     log=None, sample=None):
         self.project=project
@@ -19,6 +19,7 @@ class NGIAnalysis(object):
         self.restart_running_jobs=restart_running_jobs
         self.no_qc=no_qc 
         self.exec_mode=exec_mode
+        self.batch_analysis = batch_analysis
         self.quiet=quiet
         self.manual=manual
         self.config=config

--- a/ngi_pipeline/conductor/launchers.py
+++ b/ngi_pipeline/conductor/launchers.py
@@ -16,7 +16,7 @@ LOG = minimal_logger(__name__)
 @with_ngi_config
 def launch_analysis(projects_to_analyze, restart_failed_jobs=False,
                     restart_finished_jobs=False, restart_running_jobs=False,
-                    no_qc=False, exec_mode="sbatch",
+                    no_qc=False, exec_mode="sbatch", batch_analysis=False,
                     quiet=False, manual=False,
                     config=None, config_file_path=None):
     """Launch the appropriate analysis for each fastq file in the project.
@@ -31,7 +31,7 @@ def launch_analysis(projects_to_analyze, restart_failed_jobs=False,
             analysis=NGIAnalysis(project=project, restart_failed_jobs=restart_failed_jobs,
                         restart_finished_jobs=restart_finished_jobs,
                         restart_running_jobs=restart_running_jobs,
-                        no_qc=no_qc,
+                        no_qc=no_qc, batch_analysis=batch_analysis,
                         exec_mode=exec_mode, quiet=quiet, manual=manual,
                         config=config, config_file_path=config_file_path,
                         log=LOG)

--- a/ngi_pipeline/database/classes.py
+++ b/ngi_pipeline/database/classes.py
@@ -49,11 +49,12 @@ class CharonSession(six.with_metaclass(Singleton, requests.Session)):
                     headers=self._api_token_dict, timeout=10))
 
         self._project_params = ('projectid', 'name', 'status', 'best_practice_analysis',
-                                'sequencing_facility', 'delivery_status', 'delivery_token', 'delivery_projects')
-        self._project_reset_params = tuple(set(self._project_params) - \
+                                'sequencing_facility', 'delivery_status', 'delivery_token',
+                                'delivery_projects', 'pipeline', 'reference')
+        self._project_reset_params = tuple(set(self._project_params) -
                                            set(['projectid', 'name',
                                                 'best_practice_analysis',
-                                                'sequencing_facility']))
+                                                'sequencing_facility', 'pipeline', 'reference']))
         self._sample_params = ('sampleid', 'status', 'analysis_status', 'qc_status',
                                'genotype_status', 'genotype_concordance',
                                'total_autosomal_coverage', 'total_sequenced_reads',
@@ -80,8 +81,8 @@ class CharonSession(six.with_metaclass(Singleton, requests.Session)):
         self._base_url = charon_url
 
     # Project
-    def project_create(self, projectid, name=None, status=None,
-                       best_practice_analysis=None, sequencing_facility=None):
+    def project_create(self, projectid, name=None, status=None, best_practice_analysis=None,
+                       sequencing_facility=None, pipeline=None, reference=None):
         l_dict = locals()
         data = { k: l_dict.get(k) for k in self._project_params }
         return self.post(self.construct_charon_url('project'),
@@ -95,7 +96,9 @@ class CharonSession(six.with_metaclass(Singleton, requests.Session)):
         return self.get(self.construct_charon_url('samples', projectid)).json()
 
     def project_update(self, projectid, name=None, status=None, best_practice_analysis=None,
-                       sequencing_facility=None, delivery_status=None, delivery_token=None, delivery_projects=None):
+                       sequencing_facility=None,
+                       delivery_status=None, delivery_token=None, delivery_projects=None,
+                       pipeline=None, reference=None):
         l_dict = locals()
         data = { k: l_dict.get(k) for k in self._project_params if l_dict.get(k)}
         return self.put(self.construct_charon_url('project', projectid),

--- a/ngi_pipeline/engines/sarek/launchers.py
+++ b/ngi_pipeline/engines/sarek/launchers.py
@@ -43,7 +43,7 @@ def analyze(analysis_object):
         process_connector=slurm_conector)
 
     # iterate over the samples in the project and launch analysis in batch
-    analysis_engine.analyze_project(analysis_object, batch_analysis=True)
+    analysis_engine.analyze_project(analysis_object, batch_analysis=analysis_object.batch_analysis)
 
     # finally, let's force a sync of the local SQLite DB and Charon
     time.sleep(5)

--- a/ngi_pipeline/engines/sarek/launchers.py
+++ b/ngi_pipeline/engines/sarek/launchers.py
@@ -1,7 +1,6 @@
 import time
 
 from ngi_pipeline.engines.sarek.database import CharonConnector, TrackingConnector
-from ngi_pipeline.engines.sarek.exceptions import SampleNotValidForAnalysisError
 from ngi_pipeline.engines.sarek.local_process_tracking import update_charon_with_local_jobs_status
 from ngi_pipeline.engines.sarek.models.sarek import SarekAnalysis
 from ngi_pipeline.engines.sarek.process import SlurmConnector
@@ -43,12 +42,8 @@ def analyze(analysis_object):
         tracking_connector=tracking_connector,
         process_connector=slurm_conector)
 
-    # iterate over the samples in the project and launch analysis for each
-    for sample_object in analysis_object.project:
-        try:
-            analysis_engine.analyze_sample(sample_object, analysis_object)
-        except SampleNotValidForAnalysisError as e:
-            analysis_object.log.error(e)
+    # iterate over the samples in the project and launch analysis in batch
+    analysis_engine.analyze_project(analysis_object, batch_analysis=True)
 
     # finally, let's force a sync of the local SQLite DB and Charon
     time.sleep(5)

--- a/ngi_pipeline/engines/sarek/models/sample.py
+++ b/ngi_pipeline/engines/sarek/models/sample.py
@@ -38,6 +38,12 @@ class SarekAnalysisSample(object):
         """
         return self.analysis_object.sample_data_path(self.project_base_path, self.projectid, self.sampleid)
 
+    def project_analysis_path(self):
+        """
+        :return: the path to the analysis output for the project
+        """
+        return self.analysis_object.project_analysis_path(self.project_base_path, self.projectid)
+
     def sample_analysis_path(self):
         """
         :return: the path to the analysis output for the sample
@@ -52,6 +58,13 @@ class SarekAnalysisSample(object):
         """
         return os.path.join(self.sample_data_path(), libprepid, seqrunid)
 
+    def project_analysis_exit_code_path(self):
+        """
+        :return: the path to the exit code file for this project and analysis
+        """
+        return self.analysis_object.project_analysis_exit_code_path(
+            self.project_base_path, self.projectid)
+
     def sample_analysis_exit_code_path(self):
         """
         :return: the path to the exit code file for this sample and analysis
@@ -59,14 +72,26 @@ class SarekAnalysisSample(object):
         return self.analysis_object.sample_analysis_exit_code_path(
             self.project_base_path, self.projectid, self.sampleid)
 
+    def project_analysis_tsv_file(self):
+        """
+        :return: the path to a tsv file specifying details of analysis including this sample
+        """
+        return self.analysis_object.project_analysis_tsv_file(self.project_base_path, self.projectid)
+
     def sample_analysis_tsv_file(self):
         """
         :return: the path to the tsv file specifying the details of the analysis
         """
         return self.analysis_object.sample_analysis_tsv_file(self.project_base_path, self.projectid, self.sampleid)
 
+    def project_analysis_work_dir(self):
+        return self.analysis_object.project_analysis_work_dir(self.project_base_path, self.projectid)
+
     def sample_analysis_work_dir(self):
         return self.analysis_object.sample_analysis_work_dir(self.project_base_path, self.projectid, self.sampleid)
+
+    def project_analysis_results_dir(self):
+        return self.analysis_object.project_analysis_results_dir(self.project_base_path, self.projectid)
 
     def sample_analysis_results_dir(self):
         return self.analysis_object.sample_analysis_results_dir(self.project_base_path, self.projectid, self.sampleid)

--- a/ngi_pipeline/engines/sarek/models/sarek.py
+++ b/ngi_pipeline/engines/sarek/models/sarek.py
@@ -253,6 +253,15 @@ class SarekAnalysis(object):
         return True
 
     def analyze_project(self, analysis_object, batch_analysis=True):
+        """
+        Start the analysis of the samples in the supplied NGIAnalysis object.
+
+        :param analysis_object: a NGIAnalysis object containing the project and smaples to be
+        analyzed as well as details for the analysis
+        :param batch_analysis: boolean indicating whether analysis should be started as a single
+        batch that includes all samples or for each sample individually
+        :return: None
+        """
         analysis_samples = []
         for sample_object in analysis_object.project:
             try:
@@ -263,21 +272,21 @@ class SarekAnalysis(object):
             except SampleNotValidForAnalysisError as e:
                 analysis_object.log.error(e)
 
-        self.start_analysis(analysis_samples=analysis_samples, batch_analysis=batch_analysis)
+        self.start_analysis(
+            analysis_samples=analysis_samples,
+            batch_analysis=batch_analysis)
 
     def analyze_sample(self, sample_object, analysis_object):
         """
-        Start the analysis for the supplied NGISample object and with the analysis details contained within the supplied
-        NGIAnalysis object. If analysis is successfully started, will record the analysis in the local tracking
-        database.
+        Convert the supplied NGISample and NGIAnalysis object to a SarekAnalysisSample object.
 
-        Before starting, the status of the sample will be checked against the restart options in the analysis object.
+        The status of the sample will be checked against the restart options in the analysis object.
 
-        :raises: a SampleNotValidForAnalysisError if the sample is not eligible for analysis based on its status and the
-        analysis options in the NGIAnalysis object
+        :raises: a SampleNotValidForAnalysisError if the sample is not eligible for analysis based
+        on its status and the analysis options in the NGIAnalysis object
         :param sample_object: a NGISample object representing the sample to start analysis for
         :param analysis_object: a NGIAnalysis object containing the details for the analysis
-        :return: None
+        :return: a SarekAnalysisSample representing the sample object and analysis options
         """
 
         analysis_sample = SarekAnalysisSample(
@@ -297,7 +306,19 @@ class SarekAnalysis(object):
         return analysis_sample
 
     def start_analysis(self, analysis_samples, batch_analysis=False):
+        """
+        Start the analysis for the supplied list of SarekAnalysisSample objects. If batch_analysis
+        is True, all samples will be started together at the project level, in one batch.
+        Otherwise, the samples will be started and handled individually. Regardless of the batch
+        mode, if analysis is successfully started, the analysis will be recorded for each sample in
+        the local tracking database.
 
+        :param analysis_samples: a list of SarekAnalysisSample objects representing the samples
+        and corresponding analysis parameters to start analysis for
+        :param batch_analysis: boolean indicating whether analysis should be started as a single
+        batch that includes all samples or for each sample individually
+        :return: None
+        """
         pid = None
         for analysis_sample in analysis_samples:
             cmd = self.command_line(analysis_sample, batch_analysis=batch_analysis)

--- a/ngi_pipeline/engines/sarek/models/workflow.py
+++ b/ngi_pipeline/engines/sarek/models/workflow.py
@@ -114,6 +114,12 @@ class SarekMainStep(SarekWorkflowStep):
             analysis_sample.sample_analysis_results_dir(),
             "Reports",
             analysis_sample.sampleid)
+        if not os.path.exists(report_dir):
+            report_dir = os.path.join(
+                analysis_sample.project_analysis_results_dir(),
+                "Reports",
+                analysis_sample.sampleid)
+
         # MarkDuplicates output files may be named differently depending on if the pipeline was started with a single
         # fastq file pair or multiple file pairs
         markdups_dir = os.path.join(report_dir, "MarkDuplicates")

--- a/ngi_pipeline/engines/sarek/process.py
+++ b/ngi_pipeline/engines/sarek/process.py
@@ -244,8 +244,10 @@ class SlurmConnector(ProcessConnector):
         safe_makedir(slurm_script_dir)
         slurm_script = os.path.join(
             slurm_script_dir, "{}.{}.sbatch".format(job_name, datetime.datetime.now().strftime("%s")))
-        slurm_stdout = "{}.out".format(slurm_script)
-        slurm_stderr = "{}.err".format(slurm_script)
+        slurm_stdout = os.path.join(
+            slurm_script_dir, f"{job_name}.%j.out")
+        slurm_stderr = os.path.join(
+            slurm_script_dir, f"{job_name}.%j.err")
 
         with open(slurm_script, "w") as fh:
             fh.write(

--- a/ngi_pipeline/tests/database/test_filesystem.py
+++ b/ngi_pipeline/tests/database/test_filesystem.py
@@ -37,7 +37,7 @@ class TestCharonFunctions(unittest.TestCase):
     @mock.patch('ngi_pipeline.database.filesystem.CharonSession.seqrun_create')
     def test_create_charon_entries_from_project(self, mock_seqrun, mock_libprep, mock_sample, mock_proj):
         create_charon_entries_from_project(self.project_obj)
-        mock_proj.assert_called_once_with(best_practice_analysis='whole_genome_reseq', 
+        mock_proj.assert_called_once_with(best_practice_analysis='wgs_germline',
                                             name='S.One_20_02', 
                                             projectid='P100001', 
                                             sequencing_facility='NGI-S', 
@@ -78,7 +78,7 @@ class TestCharonFunctions(unittest.TestCase):
 
         create_charon_entries_from_project(self.project_obj, force_overwrite=True)
 
-        mock_project_ud.assert_called_once_with(best_practice_analysis='whole_genome_reseq', 
+        mock_project_ud.assert_called_once_with(best_practice_analysis='wgs_germline',
                                                 name='S.One_20_02', 
                                                 projectid='P100001', 
                                                 sequencing_facility='NGI-S', 

--- a/ngi_pipeline/tests/engines/sarek/models/test_workflow.py
+++ b/ngi_pipeline/tests/engines/sarek/models/test_workflow.py
@@ -72,8 +72,11 @@ class TestSarekMainStep(unittest.TestCase):
 
     def test_report_files(self):
         analysis_sample = mock.Mock(spec=SarekAnalysisSample)
+        analysis_sample.projectid = "this-is-a-project-id"
         analysis_sample.sampleid = "this-is-a-sample-id"
+        analysis_sample.project_analysis_path.return_value = "this-is-a-path"
         analysis_sample.sample_analysis_path.return_value = "this-is-a-path"
+        analysis_sample.project_analysis_results_dir.return_value = "this-is-the-results-path"
         analysis_sample.sample_analysis_results_dir.return_value = "this-is-the-results-path"
         with mock.patch("os.listdir") as list_mock:
             file_list = ["file1", "file2.extension", "file3.metrics", "file4.metrics"]

--- a/ngi_pipeline/tests/engines/sarek/test_local_process_tracking.py
+++ b/ngi_pipeline/tests/engines/sarek/test_local_process_tracking.py
@@ -96,6 +96,7 @@ class TestAnalysisTracker(unittest.TestCase):
             setattr(tracker.analysis_entry, key, val)
 
         expected_exit_code_path = "this-is-a-path"
+        tracker.analysis_sample.project_analysis_exit_code_path.return_value = expected_exit_code_path
         tracker.analysis_sample.sample_analysis_exit_code_path.return_value = expected_exit_code_path
 
         expected_status = ProcessRunning

--- a/ngi_pipeline/tests/fc_from_samplesheet.py
+++ b/ngi_pipeline/tests/fc_from_samplesheet.py
@@ -1,0 +1,45 @@
+import os
+import sys
+from shutil import copy
+
+from ngi_pipeline.utils.parsers import get_sample_numbers_from_samplesheet
+from ngi_pipeline.tests.generate_test_data import generate_run_id
+
+
+def paths_from_samplesheet(samplesheet_file):
+
+    samples = get_sample_numbers_from_samplesheet(samplesheet_file)
+    for sample in samples:
+        yield [
+            os.path.join(
+                sample[1],
+                f"Sample_{sample[3]}",
+                f"{sample[2]}_{sample[0]}_L{sample[5]:03d}_R{r}_001.fastq.gz")
+            for r in (1, 2)]
+
+
+def fc_from_samplesheet(samplesheet_file, base_dir, fc_name=None):
+    fc_name = fc_name or generate_run_id()
+    fc_dir = os.path.join(base_dir, fc_name)
+
+    # create the fc and copy the samplesheet there
+    os.mkdir(fc_dir)
+    copy(samplesheet_file, fc_dir)
+
+    # create the Unaligned directory to hold the fastq files
+    unaligned = os.path.join(fc_dir, "Unaligned")
+    os.mkdir(unaligned)
+
+    # iterate over the fastq files to be created and touch them
+    for fq_files in paths_from_samplesheet(samplesheet_file):
+        for fqfile in fq_files:
+            fqdir = os.path.join(unaligned, os.path.dirname(fqfile))
+            os.makedirs(fqdir, exist_ok=True)
+            open(os.path.join(fqdir, os.path.basename(fqfile)), "w").close()
+
+
+if __name__ == '__main__':
+    samplesheet_file = sys.argv[1]
+    base_dir = sys.argv[2]
+    fc_name = None if len(sys.argv) < 4 else sys.argv[3]
+    fc_from_samplesheet(samplesheet_file, base_dir, fc_name=fc_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ PyYAML>=3.11
 requests
 SQLAlchemy>=0.9.7
 xmltodict>=0.9.0
+six

--- a/scripts/ngi_pipeline_start.py
+++ b/scripts/ngi_pipeline_start.py
@@ -101,8 +101,12 @@ if __name__ == "__main__":
                   "use this value when creating records in Charon. (Optional)"))
     organize_flowcell.add_argument("-w", "--sequencing-facility", default="NGI-S", choices=('NGI-S', 'NGI-U'),
             help="The facility where sequencing was performed.")
-    organize_flowcell.add_argument("-b", "--best_practice_analysis", default="whole_genome_reseq",
+    organize_flowcell.add_argument("-b", "--best_practice_analysis", default="wgs_germline",
             help="The best practice analysis to run for this project or projects.")
+    organize_flowcell.add_argument("--pipeline", default="sarek",
+            help="The pipeline to execute for this project or projects.")
+    organize_flowcell.add_argument("--reference", default="GRCh38",
+            help="The reference genome to use for this project or projects.")
     organize_flowcell.add_argument("-f", "--force", dest="force_update", action="store_true",
             help="Force updating Charon projects. Danger danger danger. This will overwrite things.")
     organize_flowcell.add_argument("-s", "--sample", dest="restrict_to_samples", action="append",
@@ -217,6 +221,8 @@ if __name__ == "__main__":
             try:
                 create_charon_entries_from_project(project=project,
                                                    best_practice_analysis=args.best_practice_analysis,
+                                                   pipeline=args.pipeline,
+                                                   reference=args.reference,
                                                    sequencing_facility=args.sequencing_facility,
                                                    force_overwrite=args.force_update)
             except Exception as e:

--- a/scripts/ngi_pipeline_start.py
+++ b/scripts/ngi_pipeline_start.py
@@ -124,6 +124,8 @@ if __name__ == "__main__":
             help='Start the analysis of a pre-parsed project.')
     analyze_project.add_argument("--no-qc", action="store_true",
             help="Skip qc analysis.")
+    analyze_project.add_argument("--batch-analysis", action="store_true",
+            help="Batch analysis project-wise")
     analyze_project.add_argument('analyze_project_dirs', nargs='+',
             help='The path to the project folder to be analyzed.')
 
@@ -190,6 +192,7 @@ if __name__ == "__main__":
                                       restart_failed_jobs=args.restart_failed_jobs,
                                       restart_finished_jobs=args.restart_finished_jobs,
                                       restart_running_jobs=args.restart_running_jobs,
+                                      batch_analysis=args.batch_analysis,
                                       no_qc=args.no_qc,
                                       quiet=args.quiet,
                                       manual=True)

--- a/test_ngi_config.yaml
+++ b/test_ngi_config.yaml
@@ -24,11 +24,11 @@ analysis:
     # top_dir is the directory used by the pipeline as a starting point to build up the analysis run
     # see ngi_pipeline/utils/filesystem.py for details.
     # for nestor the default is /proj/a2014205/nobackup/NGI/analysis_ready
-    top_dir: /lupus/ngi/staging/wildwest/ngi2016001/nobackup/NGI
+    top_dir: /vulpes/ngi/staging/wildwest/ngi2016001/nobackup/NGI
     sthlm_root: ngi2016003
     upps_root: ngi2016001
     # for nestor it is simply /proj
-    base_root: /lupus/ngi/staging/wildwest
+    base_root: /vulpes/ngi/staging/wildwest
 
 database:
     # SQLite file to know what/where/how things are happening (state machine to back up Charon for network failure)
@@ -49,26 +49,26 @@ database:
     # );
     # Compulsory to define: to make sure you are not overwriting the production version below, it is commented out, 
     # forcing you to edit the config file
-    record_tracking_db_path: /lupus/ngi/staging/wildwest/ngi2016001/private/db/record_tracking_database.sql
+    record_tracking_db_path: /vulpes/ngi/staging/wildwest/ngi2016001/private/db/record_tracking_database.sql
 
 environment:
     project_id: ngi2016001
     # directory containing scripts like ngi_pipeline_start.py, print_running_jobs.py etc
     # on nestor the production code at /proj/a2014205/software/ngi_pipeline/scripts
-    ngi_scripts_dir:    /lupus/ngi/staging/latest/sw/ngi_pipeline/scripts
+    ngi_scripts_dir:    /vulpes/ngi/staging/latest/sw/ngi_pipeline/scripts
     conda_env: ngi_pipeline
     # Flowcell directories; the path string must contain the strings either /a2014205/ or /a2015179/
     # see ngi_pipeline/ngi_pipeline/conductor/flowcell.py:setup_analysis_directory_structure() for details
     # On nestor the default values should be /proj/a2014205/archive /proj/a2015179/archive
     flowcell_inbox: 
-            - /lupus/ngi/staging/wildwest/ngi2016001/incoming
-            - /lupus/ngi/staging/wildwest/ngi2016003/incoming
+            - /vulpes/ngi/staging/wildwest/ngi2016001/incoming
+            - /vulpes/ngi/staging/wildwest/ngi2016003/incoming
 
 logging:
     # the log file itself is compulsory to be defined, or you will get a nasty exception
     # to make sure you are defining it, and not overwriting the production one below, it is left commented out
     # default location is /proj/a2014205/ngi_resources/ngi_pipeline.log
-    log_file: /lupus/ngi/staging/wildwest/ngi2016001/private/log/ngi_pipeline.test.log
+    log_file: /vulpes/ngi/staging/wildwest/ngi2016001/private/log/ngi_pipeline.test.log
 
 paths: # Hard code paths here if you are that kind of a person
     binaries:
@@ -101,7 +101,7 @@ piper:
     #    - arg3
 
 sarek:
-    tag: 2.6
+    tag: 2.7
     tools:
         - haplotypecaller
         - snpeff


### PR DESCRIPTION
This PR enables starting one Sarek process for an entire project rather than one process per sample (i.e. to do a `batch-analysis`).

- If passing the `--batch-analysis` argument to `ngi_pipeline_start.py` when launching the analysis for a project, all samples in the project will be started in the same nexflow process (default is to start one process per sample).

- Also, upon flow cell organization, the default `best_practice_analysis`, `pipeline` and `reference` set in Charon will be `wgs_germline`, `sarek` and `GRCh38`. These default values can be overridden on the command line.

- The sbatch stdout and stderr files will have the slurm job id in the filename instead of a timestamp.