### PR TITLE
parse sample name from fastq file instead of sample directory

### DIFF
--- a/ngi_pipeline/tests/utils/test_parsers.py
+++ b/ngi_pipeline/tests/utils/test_parsers.py
@@ -110,7 +110,7 @@ class TestCommon(unittest.TestCase):
             '2,Sample_CEP-NA11992-PCR-free,CEP-NA11992-PCR-free,,,,ATGTCA,YM01,LIBRARY_NAME:CEP_Pool9'.split(','),
             '3,Sample_CEP-NA10860-PCR-free,CEP-NA10860-PCR-free,,,,AGTTCC,YM01,LIBRARY_NAME:CEP_Pool8'.split(','),
             '4,Sample_CEP-NA10860-PCR-free,CEP-NA10860-PCR-free,,,,GGTTCC,YM01,LIBRARY_NAME:CEP_Pool1'.split(','),
-            '4,Sample_CEP-NA10860-PCR-free,CEP-NA10860-PCR-free,,,,GGTTCC,YM01,LIBRARY_NAME:CEP_Pool11'.split(',')
+            '4,Sample_CEP-NA10860-PCR-free-2,CEP-NA10860-PCR-free,,,,GGTTCC,YM01,LIBRARY_NAME:CEP_Pool11'.split(',')
         ]
         samplesheet_rows = [dict(list(zip(samplesheet_header, sample))) for sample in samplesheet_samples]
         for row in samplesheet_rows[0:-1]:
@@ -119,7 +119,7 @@ class TestCommon(unittest.TestCase):
         with mock.patch('ngi_pipeline.utils.parsers.parse_samplesheet') as samplesheet_mock:
             samplesheet_mock.return_value = samplesheet_rows
             observed_sample_numbers = parsers.get_sample_numbers_from_samplesheet('samplesheet_path')
-            self.assertListEqual(['S1', 'S2', 'S1', 'S1', 'S1'], [osn[0] for osn in observed_sample_numbers])
+            self.assertListEqual(['S1', 'S2', 'S1', 'S1', 'S3'], [osn[0] for osn in observed_sample_numbers])
 
     def test_parse_samplesheet(self):
         parsed_samplesheet = parsers.parse_samplesheet(self.ss_v25)        


### PR DESCRIPTION
When organizing a flow cell, ngi_pipeline would deduce the sample_name from the name of the directory containing the fastq files (e.g. `FC/Unaligned/AB-1234/AB-1234-101`). For `bcl2fastq`, this corresponds to the `SampleID` field in the samplesheet, whereas the fastq file name prefix (up until the `_S1`) actually corresponds to the `SampleName` field in the samplesheet.

This meant that samples having multiple library preps sequenced in the same lane would not be organized together since they would have the same name but different sample ids. 

This PR changes so that ngi_pipeline deduces the sample_name from the fastq file prefix and the sample_id from the sample directory. This way, samples having different `SampleId`s but same `SampleName` in the samplesheet will be organized together.
